### PR TITLE
cleanup package.json and add graph deploy config

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -15,10 +15,7 @@ jobs:
           node-version: 16
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
-      - run: yarn install --frozen-lockfile
-        working-directory: packages/app
       - run: yarn build
-        working-directory: packages/app
       - name: Setup fleek config file
         working-directory: packages/app
         run: cp ./.fleek.dev.json ./.fleek.json
@@ -30,3 +27,11 @@ jobs:
           apiKey: ${{ secrets.FLEEK_API_KEY }}
       - name: Get the output url
         run: echo "Deploy url is ${{ steps.deploy.outputs.deployUrl }}"
+      - name: Prep graph cli for deployment
+        working-directory: packages/subgraph
+        run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
+      - name: Deploy subgraphs
+        working-directory: packages/subgraph
+        env:
+          HOSTED_SERVICE_SUBGRAPH__RINKEBY: samepant/tabula-dev
+        run: yarn deploy:rinkeby

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -15,10 +15,7 @@ jobs:
           node-version: 16
       - run: npm install -g yarn
       - run: yarn install --frozen-lockfile
-      - run: yarn install --frozen-lockfile
-        working-directory: packages/app
       - run: yarn build
-        working-directory: packages/app
       - name: Setup fleek config file
         working-directory: packages/app
         run: cp ./.fleek.prod.json ./.fleek.json
@@ -30,3 +27,11 @@ jobs:
           apiKey: ${{ secrets.FLEEK_API_KEY }}
       - name: Get the output url
         run: echo "Deploy url is ${{ steps.deploy.outputs.deployUrl }}"
+      - name: Prep graph cli for deployment
+        working-directory: packages/subgraph
+        run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
+      - name: Deploy subgraphs
+        working-directory: packages/subgraph
+        env:
+          HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN: samepant/tabula
+        run: yarn deploy:gnosis-chain

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "typescript": "^4.6.2"
   },
   "scripts": {
-    "predeploy": "yarn --cwd packages/app yarn run build",
-    "deploy": "yarn --cwd packages/app yarn deploy",
+    "build": "yarn app:build && yarn subgraph:build",
+    "app:build": "yarn --cwd packages/app build",
+    "subgraph:build": "yarn --cwd packages/subgraph build",
     "postinstall": "yarn --cwd packages/app install && yarn --cwd packages/subgraph install",
     "prepare": "husky install",
     "pre-commit": "yarn --cwd packages/app pre-commit && yarn --cwd packages/subgraph pre-commit"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -45,8 +45,6 @@
     "yup": "^0.32.11"
   },
   "scripts": {
-    "predeploy": "yarn run build",
-    "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
+    "prebuild": "yarn prepare:rinkeby && yarn codegen",
     "test": "graph test",
     "deploy:gnosis-chain": "yarn prepare:gnosis-chain && bash -c 'source .env && graph deploy --node https://api.thegraph.com/deploy/ $HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN'",
     "prepare:gnosis-chain": "mustache network_configs/gnosis-chain.json subgraph.template.yaml > subgraph.yaml",


### PR DESCRIPTION
I removed the old deploy command for the app (which deployed to github pages), and added in deploy config for the subgraphs. This deploys the subgraph to rinkeby for dev, and to gnosis chain for prod.

This needs a subgraph.yaml file before being merged in, as subgraph builds won't work without it (@asgeir-eth knows more about this than I)