### PR TITLE
Account permissions to a publication 

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "LGPL-2.1",
-  "homepage": "https://onposter.github.io/tabula",
+  "homepage": "https://onposter.github.io",
   "dependencies": {
     "@chainsafe/web3-context": "^1.3.1",
     "@emotion/react": "^11.8.2",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,6 +16,7 @@ import { PreviewPostView } from "./components/views/publication/PreviewPostView"
 import { ArticleView } from "./components/views/publication/ArticleView"
 import ScrollToTop from "./components/commons/ScrollToTop"
 import { subgraphClient } from "./services/graphql"
+import { PermissionView } from "./components/views/publication/PermissionView"
 const App: React.FC = () => {
   const navigate = useNavigate()
   const { active } = useWeb3React()
@@ -40,6 +41,7 @@ const App: React.FC = () => {
             <Route path="/publication/preview-post" element={<PreviewPostView />} />
             <Route path="/publication/post/:postId" element={<PublicationPostView />} />
             <Route path="/publication/article/:articleId" element={<ArticleView />} />
+            <Route path="/publication/permission/:type" element={<PermissionView />} />
             <Route path=":address" element={<PublishersView />} />
             <Route path=":address/:postId" element={<PostView />} />
           </Routes>

--- a/packages/app/src/components/commons/Checkbox.tsx
+++ b/packages/app/src/components/commons/Checkbox.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { CheckboxProps, FormControlLabel, Checkbox, styled, Box } from "@mui/material"
+import { palette } from "../../theme"
+
+interface CustomCheckboxProps extends CheckboxProps {
+  label: string
+}
+
+const CheckboxContainer = styled(Box)({
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  width: 24,
+  height: 24,
+  borderRadius: 4,
+  border: `2px solid ${palette.secondary[1000]}`,
+  background: palette.whites[1000],
+})
+const CheckboxChecked = styled(Box)({
+  width: 12,
+  height: 12,
+  borderRadius: 2,
+  background: palette.secondary[1000],
+})
+export const CustomCheckbox: React.FC<CustomCheckboxProps> = (props) => {
+  return (
+    <FormControlLabel
+      control={
+        <Checkbox
+          {...props}
+          color="secondary"
+          icon={<CheckboxContainer />}
+          checkedIcon={
+            <CheckboxContainer>
+              <CheckboxChecked />
+            </CheckboxContainer>
+          }
+        />
+      }
+      label={props.label}
+    />
+  )
+}

--- a/packages/app/src/components/commons/PermissionItem.tsx
+++ b/packages/app/src/components/commons/PermissionItem.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Grid } from "@mui/material"
+import { styled } from "@mui/styles"
+import { palette } from "../../theme"
+import { Permission } from "../../models/publication"
+import EditIcon from "@mui/icons-material/Edit"
+import { WalletBadge } from "./WalletBadge"
+
+const PermissionItemContainer = styled(Grid)({
+  minHeight: "48px",
+  background: palette.grays[100],
+  borderRadius: 4,
+  padding: "10px 20px",
+  cursor: "pointer",
+  "&:hover": {
+    background: palette.grays[200],
+  },
+})
+const PermissionItemIconGrid = styled(Grid)({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#91908e",
+})
+
+const PermissionItemEditContainer = styled(Grid)({
+  border: `2px solid ${palette.grays[600]}`,
+  background: palette.whites[600],
+  borderRadius: 4,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  width: 32,
+  height: 32,
+  cursor: "pointer",
+})
+
+type PermissionItemProps = {
+  permission: Permission
+  onClick: (id: string) => void
+}
+const PermissionItem: React.FC<PermissionItemProps> = ({ permission, onClick }) => {
+  const { address, id } = permission
+
+  return (
+    <PermissionItemContainer container alignItems={"center"} onClick={() => onClick(id ? id : "")}>
+      <Grid item xs={10}>
+        <WalletBadge address={address} />
+      </Grid>
+      <PermissionItemIconGrid item xs={2}>
+        <PermissionItemEditContainer>
+          <EditIcon style={{ color: palette.grays[1000] }} />
+        </PermissionItemEditContainer>
+      </PermissionItemIconGrid>
+    </PermissionItemContainer>
+  )
+}
+
+export default PermissionItem

--- a/packages/app/src/components/commons/PermissionItem.tsx
+++ b/packages/app/src/components/commons/PermissionItem.tsx
@@ -37,20 +37,29 @@ const PermissionItemEditContainer = styled(Grid)({
 
 type PermissionItemProps = {
   permission: Permission
+  canEdit: boolean
   onClick: (id: string) => void
 }
-const PermissionItem: React.FC<PermissionItemProps> = ({ permission, onClick }) => {
+const PermissionItem: React.FC<PermissionItemProps> = ({ permission, canEdit, onClick }) => {
   const { address, id } = permission
 
   return (
-    <PermissionItemContainer container alignItems={"center"} onClick={() => onClick(id ? id : "")}>
+    <PermissionItemContainer
+      container
+      alignItems={"center"}
+      onClick={() => {
+        canEdit && onClick(id ? id : "")
+      }}
+    >
       <Grid item xs={10}>
         <WalletBadge address={address} />
       </Grid>
       <PermissionItemIconGrid item xs={2}>
-        <PermissionItemEditContainer>
-          <EditIcon style={{ color: palette.grays[1000] }} />
-        </PermissionItemEditContainer>
+        {canEdit && (
+          <PermissionItemEditContainer>
+            <EditIcon style={{ color: palette.grays[1000] }} />
+          </PermissionItemEditContainer>
+        )}
       </PermissionItemIconGrid>
     </PermissionItemContainer>
   )

--- a/packages/app/src/components/views/publication/PermissionView.tsx
+++ b/packages/app/src/components/views/publication/PermissionView.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from "react"
+import {
+  Grid,
+  Box,
+  Typography,
+  styled,
+  TextField,
+  Divider,
+  Button,
+  FormHelperText,
+  CircularProgress,
+} from "@mui/material"
+import { palette, typography } from "../../../theme"
+import CloseIcon from "@mui/icons-material/Close"
+import { useNavigate, useParams } from "react-router-dom"
+import { CustomCheckbox } from "../../commons/Checkbox"
+import { Controller, useForm } from "react-hook-form"
+
+import { ethers } from "ethers"
+import usePoster from "../../../services/poster/hooks/usePoster"
+import { usePublicationContext } from "../../../services/publications/contexts"
+import usePublication from "../../../services/publications/hooks/usePublication"
+import { find } from "lodash"
+import { WalletBadge } from "../../commons/WalletBadge"
+
+type OptionsType = {
+  label: string
+  key:
+    | "articleCreate"
+    | "articleUpdate"
+    | "articleDelete"
+    | "publicationDelete"
+    | "publicationUpdate"
+    | "publicationPermissions"
+}
+
+type PermissionFormType = {
+  articleCreate: boolean
+  articleDelete: boolean
+  articleUpdate: boolean
+  publicationDelete: boolean
+  publicationPermissions: boolean
+  publicationUpdate: boolean
+  account: string
+}
+
+const PermissionContainer = styled(Grid)({
+  justifyContent: "center",
+  alignItems: "center",
+  height: "100vh",
+  gap: 24,
+  flexDirection: "column",
+})
+
+const ARTICLES_OPTIONS: OptionsType[] = [
+  {
+    label: "Can create posts",
+    key: "articleCreate",
+  },
+  {
+    label: "Can edit posts",
+    key: "articleUpdate",
+  },
+  {
+    label: "Can delete posts",
+    key: "articleDelete",
+  },
+]
+const PUBLICATIONS_OPTIONS: OptionsType[] = [
+  {
+    label: "Can delete the publication",
+    key: "publicationDelete",
+  },
+
+  {
+    label: "Can edit the publication",
+    key: "publicationUpdate",
+  },
+  {
+    label: "Can edit the publication permissions",
+    key: "publicationPermissions",
+  },
+]
+
+const INITIAL_VALUE = {
+  articleCreate: false,
+  articleDelete: false,
+  articleUpdate: false,
+  publicationDelete: false,
+  publicationPermissions: false,
+  publicationUpdate: false,
+  account: "",
+}
+
+export const PermissionView: React.FC = () => {
+  const navigate = useNavigate()
+  const { givePermission } = usePoster()
+  const { type } = useParams<{ type: "edit" | "new" }>()
+  const { publication, permission, savePublication } = usePublicationContext()
+  const { data: publicationRefetch, refetch } = usePublication(publication?.id || "")
+  const [loading, setLoading] = useState<boolean>(false)
+  const {
+    control,
+    handleSubmit,
+    watch,
+    clearErrors,
+    setError,
+    setValue,
+    formState: { errors },
+  } = useForm({
+    defaultValues: INITIAL_VALUE,
+  })
+  const account = watch("account")
+
+  useEffect(() => {
+    if (type === "edit" && permission) {
+      const {
+        articleCreate,
+        articleDelete,
+        articleUpdate,
+        publicationDelete,
+        publicationPermissions,
+        publicationUpdate,
+      } = permission
+      setValue("articleCreate", articleCreate)
+      setValue("articleDelete", articleDelete)
+      setValue("articleUpdate", articleUpdate)
+      setValue("publicationDelete", publicationDelete)
+      setValue("publicationPermissions", publicationPermissions)
+      setValue("publicationUpdate", publicationUpdate)
+    }
+  }, [type, setValue, permission])
+
+  console.log("watch()", watch())
+
+  useEffect(() => {
+    if (account) {
+      const isValid = ethers.utils.isAddress(account)
+      if (!isValid) {
+        setError("account", {
+          type: "manual",
+          message: "Please provide a valid address",
+        })
+      } else {
+        clearErrors("account")
+      }
+    }
+  }, [account, setError, clearErrors])
+
+  //Execute poll interval to know the latest permission indexed
+  useEffect(() => {
+    if (loading) {
+      const interval = setInterval(() => {
+        refetch()
+      }, 5000)
+      return () => clearInterval(interval)
+    }
+  }, [refetch, loading])
+
+  //Check if the new permission is already indexed
+  useEffect(() => {
+    const permissions = publicationRefetch?.permissions || []
+    if (permissions && permissions.length > 0 && account) {
+      const isIndexed = find(permissions, { address: account.toLowerCase() })
+      if (isIndexed) {
+        setLoading(false)
+        savePublication(publicationRefetch)
+        navigate(-1)
+      }
+    }
+  }, [savePublication, account, publicationRefetch, navigate])
+
+  const onSubmitHandler = (data: PermissionFormType) => {
+    if (type === "new") {
+      handleNewPermission(data, "new")
+    }
+    if (type === "edit") {
+      handleNewPermission(data, "edit")
+    }
+  }
+
+  const handleNewPermission = async (data: PermissionFormType, type: "new" | "edit") => {
+    if (publication) {
+      setLoading(true)
+      await givePermission({
+        action: "publication/permissions",
+        id: publication.id,
+        account: type === "new" ? data.account : permission?.address || "",
+        permissions: {
+          "article/create": data.articleCreate,
+          "article/update": data.articleUpdate,
+          "article/delete": data.articleDelete,
+          "publication/delete": data.publicationDelete,
+          "publication/update": data.publicationUpdate,
+          "publication/permissions": data.publicationPermissions,
+        },
+      }).then((res) => {
+        if (res && res.error) setLoading(false)
+      })
+    }
+  }
+
+  return (
+    <PermissionContainer container>
+      <Grid container maxWidth={350} flexDirection="column" gap={3}>
+        <Grid item width={"100%"}>
+          <Box display="flex" alignItems={"center"} justifyContent={"space-between"} mb={2}>
+            <Typography fontFamily={typography.fontFamilies.sans} variant="h5" m={0}>
+              {type === "new" ? "Add new permission" : "Update permission"}
+            </Typography>
+            <CloseIcon style={{ cursor: "pointer" }} onClick={() => navigate(-1)} />
+          </Box>
+        </Grid>
+        <Grid item width={"100%"}>
+          <form onSubmit={handleSubmit((data) => onSubmitHandler(data as PermissionFormType))}>
+            <Grid container flexDirection="column" gap={3}>
+              {type === "new" && (
+                <Grid item>
+                  <Controller
+                    control={control}
+                    name={"account"}
+                    render={({ field }) => (
+                      <TextField {...field} placeholder="Permission address" sx={{ width: "100%" }} />
+                    )}
+                  />
+                  {errors && errors.account && (
+                    <FormHelperText sx={{ color: palette.secondary[1000], textTransform: "capitalize" }}>
+                      {errors.account.message}
+                    </FormHelperText>
+                  )}
+                </Grid>
+              )}
+              {type === "edit" && permission && (
+                <Grid item>
+                  <WalletBadge address={permission.address} />
+                </Grid>
+              )}
+              <Grid item>
+                <Grid container flexDirection="column" gap={1}>
+                  <Grid item>
+                    <Typography fontFamily={typography.fontFamilies.sans} variant="body1" fontWeight={"bold"}>
+                      Post Permissions
+                    </Typography>
+                  </Grid>
+                  {ARTICLES_OPTIONS.map(({ key, label }) => (
+                    <Grid item key={key}>
+                      <Controller
+                        control={control}
+                        name={key}
+                        render={({ field }) => <CustomCheckbox {...field} checked={field.value} label={label} />}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              </Grid>
+
+              <Grid item>
+                <Grid container flexDirection="column" gap={1}>
+                  <Grid item>
+                    <Typography fontFamily={typography.fontFamilies.sans} variant="body1" fontWeight={"bold"}>
+                      Publication Permissions
+                    </Typography>
+                  </Grid>
+                  {PUBLICATIONS_OPTIONS.map(({ key, label }) => (
+                    <Grid item key={key}>
+                      <Controller
+                        control={control}
+                        name={key}
+                        render={({ field }) => <CustomCheckbox {...field} checked={field.value} label={label} />}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+              </Grid>
+
+              <Divider />
+
+              {type === "new" && (
+                <Grid item display="flex" justifyContent={"flex-end"}>
+                  <Button variant="contained" size="medium" disabled={loading} type="submit">
+                    {loading && <CircularProgress size={20} sx={{ marginRight: 1 }} />}
+                    Add Permission
+                  </Button>
+                </Grid>
+              )}
+
+              {type === "edit" && (
+                <Grid item display="flex" justifyContent={"space-between"}>
+                  <Button variant="outlined" size="medium" onClick={() => navigate("/publication/permission")}>
+                    Delete
+                  </Button>
+                  <Button variant="contained" size="medium" disabled={loading} type="submit">
+                    {loading && <CircularProgress size={20} sx={{ marginRight: 1 }} />}
+                    Update
+                  </Button>
+                </Grid>
+              )}
+            </Grid>
+          </form>
+        </Grid>
+      </Grid>
+    </PermissionContainer>
+  )
+}

--- a/packages/app/src/components/views/publication/PublicationPostView.tsx
+++ b/packages/app/src/components/views/publication/PublicationPostView.tsx
@@ -2,11 +2,11 @@ import { Avatar, CircularProgress, Grid, styled, Typography } from "@mui/materia
 import React, { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
 import { usePublicationContext } from "../../../services/publications/contexts"
-// import { usePublicationContext } from "../../../services/publications/contexts"
 import usePublication from "../../../services/publications/hooks/usePublication"
 import { palette, typography } from "../../../theme"
 import { ViewContainer } from "../../commons/ViewContainer"
 import PublicationPage from "../../layout/PublicationPage"
+import { PermissionSection } from "./components/PermissionSection"
 import PostSection from "./components/PostSection"
 import PublicationTabs from "./components/PublicationTabs"
 
@@ -26,8 +26,8 @@ export const PublicationPostView: React.FC = () => {
   const { postId } = useParams<{ postId: string }>()
   const { savePublication } = usePublicationContext()
   const { data: publication, loading, executeQuery } = usePublication(postId || "")
-  const [currentTab, setCurrentTab] = useState<string>("posts")
-
+  const [currentTab, setCurrentTab] = useState<"posts" | "permissions" | "settings">("posts")
+  
   useEffect(() => {
     if (postId) {
       executeQuery()
@@ -82,6 +82,7 @@ export const PublicationPostView: React.FC = () => {
             <Grid item>
               <PublicationTabs onChange={setCurrentTab} />
               {currentTab === "posts" && <PostSection />}
+              {currentTab === "permissions" && <PermissionSection />}
             </Grid>
           </Grid>
         </ViewContainer>

--- a/packages/app/src/components/views/publication/components/PermissionSection.tsx
+++ b/packages/app/src/components/views/publication/components/PermissionSection.tsx
@@ -5,13 +5,17 @@ import AddIcon from "@mui/icons-material/Add"
 import { usePublicationContext } from "../../../../services/publications/contexts"
 import PermissionItem from "../../../commons/PermissionItem"
 import { useNavigate } from "react-router-dom"
-import { usersWithPermissions } from "../../../../utils/permission"
+import { havePublicationPermission, usersWithPermissions } from "../../../../utils/permission"
+
+import { useWeb3React } from "@web3-react/core"
 
 export const PermissionSection: React.FC = () => {
   const navigate = useNavigate()
+  const { account } = useWeb3React()
   const { publication, savePermission } = usePublicationContext()
   const permissions = publication?.permissions || []
   const usersPermissions = usersWithPermissions(permissions)
+  const havePermissionToEdit = havePublicationPermission(permissions, account || "")
   return (
     <>
       <Grid container justifyContent="space-between" alignItems={"center"} my={4}>
@@ -38,6 +42,7 @@ export const PermissionSection: React.FC = () => {
             <Grid item sx={{ width: "100%" }} key={permission.id || ""}>
               <PermissionItem
                 permission={permission}
+                canEdit={havePermissionToEdit}
                 onClick={() => {
                   savePermission(permission)
                   navigate("/publication/permission/edit")

--- a/packages/app/src/components/views/publication/components/PermissionSection.tsx
+++ b/packages/app/src/components/views/publication/components/PermissionSection.tsx
@@ -5,12 +5,13 @@ import AddIcon from "@mui/icons-material/Add"
 import { usePublicationContext } from "../../../../services/publications/contexts"
 import PermissionItem from "../../../commons/PermissionItem"
 import { useNavigate } from "react-router-dom"
+import { usersWithPermissions } from "../../../../utils/permission"
 
 export const PermissionSection: React.FC = () => {
   const navigate = useNavigate()
   const { publication, savePermission } = usePublicationContext()
   const permissions = publication?.permissions || []
-
+  const usersPermissions = usersWithPermissions(permissions)
   return (
     <>
       <Grid container justifyContent="space-between" alignItems={"center"} my={4}>
@@ -32,8 +33,8 @@ export const PermissionSection: React.FC = () => {
         </Grid>
       </Grid>
       <Grid container flexDirection="column" alignItems="flex-start" justifyContent={"flex-start"} gap={2}>
-        {permissions.length > 0 &&
-          permissions.map((permission) => (
+        {usersPermissions.length > 0 &&
+          usersPermissions.map((permission) => (
             <Grid item sx={{ width: "100%" }} key={permission.id || ""}>
               <PermissionItem
                 permission={permission}

--- a/packages/app/src/components/views/publication/components/PermissionSection.tsx
+++ b/packages/app/src/components/views/publication/components/PermissionSection.tsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { Grid, Typography, Button } from "@mui/material"
+import { palette, typography } from "../../../../theme"
+import AddIcon from "@mui/icons-material/Add"
+import { usePublicationContext } from "../../../../services/publications/contexts"
+import PermissionItem from "../../../commons/PermissionItem"
+import { useNavigate } from "react-router-dom"
+
+export const PermissionSection: React.FC = () => {
+  const navigate = useNavigate()
+  const { publication, savePermission } = usePublicationContext()
+  const permissions = publication?.permissions || []
+
+  return (
+    <>
+      <Grid container justifyContent="space-between" alignItems={"center"} my={4}>
+        <Grid item>
+          <Typography
+            color={palette.grays[1000]}
+            variant="h5"
+            fontFamily={typography.fontFamilies.sans}
+            sx={{ margin: 0 }}
+          >
+            Permissions
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Button variant="contained" size="medium" onClick={() => navigate("/publication/permission/new")}>
+            <AddIcon style={{ marginRight: 13 }} />
+            New Permission
+          </Button>
+        </Grid>
+      </Grid>
+      <Grid container flexDirection="column" alignItems="flex-start" justifyContent={"flex-start"} gap={2}>
+        {permissions.length > 0 &&
+          permissions.map((permission) => (
+            <Grid item sx={{ width: "100%" }} key={permission.id || ""}>
+              <PermissionItem
+                permission={permission}
+                onClick={() => {
+                  savePermission(permission)
+                  navigate("/publication/permission/edit")
+                }}
+              />
+            </Grid>
+          ))}
+      </Grid>
+    </>
+  )
+}

--- a/packages/app/src/components/views/publication/components/PermissionSection.tsx
+++ b/packages/app/src/components/views/publication/components/PermissionSection.tsx
@@ -29,12 +29,14 @@ export const PermissionSection: React.FC = () => {
             Permissions
           </Typography>
         </Grid>
-        <Grid item>
-          <Button variant="contained" size="medium" onClick={() => navigate("/publication/permission/new")}>
-            <AddIcon style={{ marginRight: 13 }} />
-            New Permission
-          </Button>
-        </Grid>
+        {havePermissionToEdit && (
+          <Grid item>
+            <Button variant="contained" size="medium" onClick={() => navigate("/publication/permission/new")}>
+              <AddIcon style={{ marginRight: 13 }} />
+              New Permission
+            </Button>
+          </Grid>
+        )}
       </Grid>
       <Grid container flexDirection="column" alignItems="flex-start" justifyContent={"flex-start"} gap={2}>
         {usersPermissions.length > 0 &&

--- a/packages/app/src/components/views/publication/components/PublicationTabs.tsx
+++ b/packages/app/src/components/views/publication/components/PublicationTabs.tsx
@@ -13,13 +13,15 @@ export const PUBLICATIONS_TABS_OPTIONS = [
 ]
 
 type PublicationTabsProps = {
-  onChange: (tab: string) => void
+  onChange: (tab: "posts" | "permissions" | "settings") => void
 }
 
 const PublicationTabs: React.FC<PublicationTabsProps> = ({ onChange }) => {
-  const [currentTab, setCurrentTab] = useState<string>(PUBLICATIONS_TABS_OPTIONS[0].value)
+  const [currentTab, setCurrentTab] = useState<"posts" | "permissions" | "settings">(
+    PUBLICATIONS_TABS_OPTIONS[0].value as "posts" | "permissions" | "settings",
+  )
 
-  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+  const handleChange = (event: React.SyntheticEvent, newValue: "posts" | "permissions" | "settings") => {
     setCurrentTab(newValue)
   }
 
@@ -28,7 +30,7 @@ const PublicationTabs: React.FC<PublicationTabsProps> = ({ onChange }) => {
       onChange(currentTab)
     }
   }, [onChange, currentTab])
-  
+
   return (
     <PublicationStyledTabs
       value={currentTab}

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -11,7 +11,7 @@ import { getLibrary } from "./config"
 ReactDOM.render(
   <React.StrictMode>
     <Web3ReactProvider getLibrary={getLibrary}>
-      <HashRouter basename="/">
+      <HashRouter >
         <ThemeProvider theme={day}>
           <CssBaseline />
           <App />

--- a/packages/app/src/models/publication.ts
+++ b/packages/app/src/models/publication.ts
@@ -1,6 +1,21 @@
 export interface Permission {
   id: string
   address: string
+  articleCreate: boolean
+  articleDelete: boolean
+  articleUpdate: boolean
+  publicationDelete: boolean
+  publicationPermissions: boolean
+  publicationUpdate: boolean
+}
+
+export interface PermissionAction {
+  "article/create": boolean
+  "article/update": boolean
+  "article/delete": boolean
+  "publication/delete": boolean
+  "publication/update": boolean
+  "publication/permissions": boolean
 }
 
 export interface Publications {
@@ -20,7 +35,6 @@ export interface Post {
   tags?: string[] | null
   title: string
 }
-
 export interface Article {
   title: string
   article: string

--- a/packages/app/src/services/poster/hooks/usePoster.ts
+++ b/packages/app/src/services/poster/hooks/usePoster.ts
@@ -3,11 +3,12 @@ import { useState } from "react"
 import { useNotification } from "../../../hooks/useNotification"
 import { useWallet } from "../../../hooks/useWallet"
 import { getContract } from "../contracts/contract"
-import { PosterArticle, Publication } from "../type"
+import { PosterArticle, PosterPermission, Publication } from "../type"
 
 const PUBLICATION_TAG = "PUBLICATION" // PUBLICATION
 const POSTER_CONTRACT = process.env.REACT_APP_POSTER_CONTRACT
 const URL = "https://rinkeby.etherscan.io/tx/"
+
 const usePoster = () => {
   const openNotification = useNotification()
   const contract = getContract(POSTER_CONTRACT as string)
@@ -99,6 +100,31 @@ const usePoster = () => {
     }
   }
 
-  return { createPublication, createArticle, loading }
+  const givePermission = async (fields: PosterPermission): Promise<any> => {
+    if (signer) {
+      setLoading(true)
+      const poster = contract.connect(signer)
+      try {
+        const tx = await poster.post(JSON.stringify(fields), PUBLICATION_TAG)
+        const receipt: TransactionReceipt = await tx.wait()
+        setLoading(false)
+        openNotification({
+          message: "Execute transaction confirmed!",
+          autoHideDuration: 5000,
+          variant: "success",
+          detailsLink: URL + receipt.transactionHash,
+        })
+      } catch (error: any) {
+        setLoading(false)
+        openNotification({
+          message: "An error has happened with execute transaction!",
+          variant: "error",
+          autoHideDuration: 5000,
+        })
+        return { error: true, message: error.message }
+      }
+    }
+  }
+  return { createPublication, createArticle, givePermission, loading }
 }
 export default usePoster

--- a/packages/app/src/services/poster/type.ts
+++ b/packages/app/src/services/poster/type.ts
@@ -1,4 +1,4 @@
-import { Article, Publications } from "../../models/publication"
+import { Article, PermissionAction, Publications } from "../../models/publication"
 
 export interface Publication extends Omit<Publications, "id"> {
   action: "publication/create" | "publication/update" | "publication/delete" | "publication/permissions"
@@ -8,4 +8,11 @@ export interface PosterArticle extends Article {
   action: "article/create" | "article/update" | "article/delete" | "article/permissions"
   publicationId: string
   authors?: string[]
+}
+
+export interface PosterPermission {
+  action: "publication/permissions"
+  id: string
+  account: string
+  permissions: PermissionAction
 }

--- a/packages/app/src/services/publications/contexts/publication.context.tsx
+++ b/packages/app/src/services/publications/contexts/publication.context.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Article, Publications } from "../../../models/publication"
+import { Article, Permission, Publications } from "../../../models/publication"
 import { createGenericContext } from "../../../utils/create-generic-context"
 
 import { PublicationContextType, PublicationProviderProps } from "./publication.types"
@@ -11,11 +11,13 @@ const PublicationProvider = ({ children }: PublicationProviderProps) => {
   const [publication, setPublication] = useState<Publications | undefined>(undefined)
   const [draftArticle, setDraftArticle] = useState<Article | undefined>(undefined)
   const [article, setArticle] = useState<Article | undefined>(undefined)
+  const [permission, setPermission] = useState<Permission | undefined>(undefined)
 
   const savePublication = (publication: Publications | undefined) => setPublication(publication)
   const savePublications = (publications: Publications[] | undefined) => setPublications(publications)
   const saveDraftArticle = (article: Article) => setDraftArticle(article)
   const saveArticle = (article: Article) => setArticle(article)
+  const savePermission = (permission: Permission) => setPermission(permission)
 
   return (
     <PublicationContextProvider
@@ -24,6 +26,8 @@ const PublicationProvider = ({ children }: PublicationProviderProps) => {
         publications,
         draftArticle,
         article,
+        permission,
+        savePermission,
         savePublication,
         savePublications,
         saveArticle,

--- a/packages/app/src/services/publications/contexts/publication.types.ts
+++ b/packages/app/src/services/publications/contexts/publication.types.ts
@@ -1,11 +1,13 @@
 import { ReactNode } from "react"
-import { Article, Publications } from "../../../models/publication"
+import { Article, Permission, Publications } from "../../../models/publication"
 
 export type PublicationContextType = {
   publication: Publications | undefined
   publications: Publications[] | undefined
   draftArticle: Article | undefined
   article: Article | undefined
+  permission: Permission | undefined
+  savePermission: (permission: Permission) => void
   saveDraftArticle: (article: Article) => void
   savePublication: (publication: Publications | undefined) => void
   savePublications: (publications: Publications[] | undefined) => void

--- a/packages/app/src/services/publications/queries.ts
+++ b/packages/app/src/services/publications/queries.ts
@@ -11,6 +11,12 @@ export const GET_PUBLICATIONS_QUERY = gql`
       permissions {
         id
         address
+        articleCreate
+        articleDelete
+        articleUpdate
+        publicationDelete
+        publicationPermissions
+        publicationUpdate
       }
       lastUpdated
     }
@@ -28,6 +34,12 @@ export const GET_PUBLICATION_QUERY = gql`
       permissions {
         id
         address
+        articleCreate
+        articleDelete
+        articleUpdate
+        publicationDelete
+        publicationPermissions
+        publicationUpdate
       }
       articles(orderDirection: asc) {
         id

--- a/packages/app/src/theme/index.ts
+++ b/packages/app/src/theme/index.ts
@@ -213,6 +213,7 @@ theme = createTheme(theme, {
             backgroundColor: palette.primary[800],
             boxShadow: "0 4px rgba(0,0,0,0.1), inset 0 -4px 4px #97220100",
           },
+          
         },
         sizeSmall: {
           fontSize: "0.75rem",

--- a/packages/app/src/utils/permission.ts
+++ b/packages/app/src/utils/permission.ts
@@ -27,12 +27,25 @@ export const usersWithPermissions = (permissions: Permission[]): Permission[] =>
       permission.articleDelete ||
       permission.articleUpdate ||
       permission.publicationDelete ||
-      permission.publicationPermissions ||
-      permission.publicationUpdate
+      permission.publicationUpdate ||
+      permission.publicationPermissions
     ) {
       list = permission
     }
     return list
   })
   return withPermissions || []
+}
+
+export const havePublicationPermission = (permissions: Permission[], address: string): boolean => {
+  const permission = filter(permissions, { address: address.toLowerCase() })
+  if (permission && permission.length > 0) {
+    if (permission[0].publicationPermissions) {
+      return true
+    } else {
+      return false
+    }
+  } else {
+    return false
+  }
 }

--- a/packages/app/src/utils/permission.ts
+++ b/packages/app/src/utils/permission.ts
@@ -18,3 +18,21 @@ export const havePermission = (permissions: Permission[], address: string): bool
     return false
   }
 }
+
+export const usersWithPermissions = (permissions: Permission[]): Permission[] => {
+  const withPermissions = permissions.filter((permission) => {
+    let list
+    if (
+      permission.articleCreate ||
+      permission.articleDelete ||
+      permission.articleUpdate ||
+      permission.publicationDelete ||
+      permission.publicationPermissions ||
+      permission.publicationUpdate
+    ) {
+      list = permission
+    }
+    return list
+  })
+  return withPermissions || []
+}


### PR DESCRIPTION
closed #8 

Completed tasks

- [x] Create Publication Permission UI for Add/Update/Delete Permission.
- [x] Integrate permissions actions with the contract
- [x] Add a poll interval after success transaction to improve the UX by redirecting the user to the proper screen after the transaction is already indexed.
- [x] If the user press "Remove User." we hit the contract call and set all fields (checkboxes) to false and then only show the users that have some permissions on true.

Tests:
https://rinkeby.etherscan.io/tx/0x6d251b155a7f497fe72fde33203f1ccc9de8edf519445d05bdfe3c2a5c1a9128
https://rinkeby.etherscan.io/tx/0x84839ab35825c78c990139b79302f97405862eb72716b6596d2ed88d2339536b
https://rinkeby.etherscan.io/tx/0xf31edb1965d6de4ffae0a3fd578cf5597eac687a3b907a8ef440200da64b8ce6

Screens:

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/19823989/163033204-bebeaf58-e4af-4421-9d49-eaa9ea711dcf.png">
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/19823989/163033245-a96d178e-d370-478d-9285-116cca5521fd.png">
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/19823989/163033292-9f472d1f-a4da-4d76-9b66-7cce0a31b10d.png">
