### PR TITLE
Article Tag Fix

### DIFF
--- a/packages/app/src/components/commons/PostItem.tsx
+++ b/packages/app/src/components/commons/PostItem.tsx
@@ -101,11 +101,17 @@ const PostItem: React.FC<PostItemProps> = ({ article, couldUpdate, couldDelete }
           <Typography fontFamily={typography.fontFamilies.sans} variant="subtitle1" fontWeight={600}>
             {articleTitle}
           </Typography>
-          <Stack alignItems="center" direction="row" spacing={2}>
+          <Stack alignItems="left" spacing={1}>
             {date && <Typography variant="body2">{moment(date).format("MMMM DD, YYYY")}</Typography>}
-            <Stack alignItems="center" direction="row" spacing={1}>
-              {tags && tags.length > 0 && tags.map((tag, index) => <Chip label={tag} size="small" key={index} />)}
-            </Stack>
+            <Grid container spacing={0.5} sx={{ marginLeft: -0.5 }}>
+              {tags &&
+                tags.length > 0 &&
+                tags.map((tag, index) => (
+                  <Grid item>
+                    <Chip sx={{ height: "100%" }} label={tag} size="small" key={index} />
+                  </Grid>
+                ))}
+            </Grid>
           </Stack>
           <Typography
             variant="body1"
@@ -113,7 +119,7 @@ const PostItem: React.FC<PostItemProps> = ({ article, couldUpdate, couldDelete }
               color: palette.grays[900],
               fontSize: 14,
               lineHeight: 1.5,
-              mt: 1,
+              mt: 2,
             }}
           >
             {articleDescription}

--- a/packages/app/src/components/views/publication/ArticleView.tsx
+++ b/packages/app/src/components/views/publication/ArticleView.tsx
@@ -110,11 +110,15 @@ export const ArticleView: React.FC<ArticleViewProps> = ({ updateChainId }) => {
                 </Grid>
               )}
               {article.publication && (
-                <Stack alignItems="center" direction="row" spacing={1} my={1}>
+                <Grid container spacing={1} sx={{ marginLeft: -0.5 }}>
                   {article.tags &&
                     article.tags.length > 0 &&
-                    article.tags.map((tag, index) => <Chip label={tag} size="small" key={index} />)}
-                </Stack>
+                    article.tags.map((tag, index) => (
+                      <Grid item>
+                        <Chip sx={{ height: "100%" }} label={tag} size="small" key={index} />
+                      </Grid>
+                    ))}
+                </Grid>
               )}
               <Grid item my={5}>
                 <Markdown>{articleToShow}</Markdown>

--- a/packages/app/src/components/views/publication/ArticleView.tsx
+++ b/packages/app/src/components/views/publication/ArticleView.tsx
@@ -1,4 +1,4 @@
-import { Chip, CircularProgress, Divider, Grid, Stack, Typography } from "@mui/material"
+import { Chip, CircularProgress, Divider, Grid, Typography } from "@mui/material"
 import moment from "moment"
 import React, { useEffect, useState } from "react"
 import { Helmet } from "react-helmet"


### PR DESCRIPTION
# Description

Fixes #149 
![Image of tags overrunning their container](https://user-images.githubusercontent.com/8453294/180245560-f5285090-3e96-4cd1-ac3a-04ab22ba560b.png)

# Implementation

This uses `<Grid>` instead of `<Stack>` to render the article tags, since Grid allows elements to wrap. I implemented this change in both `packages/app/src/components/views/publication/ArticleView.tsx` and `packages/app/src/components/commons/PostItem.tsx` since they both experienced the same issue.

# Additional Context
In the publication view:
![Screen Shot 2022-07-21 at 2 21 58 PM](https://user-images.githubusercontent.com/6718506/180287058-be85f61c-830c-4ddc-a361-ec58076a1fca.png)

In article view:
![Screen Shot 2022-07-21 at 2 25 44 PM](https://user-images.githubusercontent.com/6718506/180287067-e9f7c414-8dff-474b-8a87-e032505a1ae5.png)

