### PR TITLE
Adds preview tab to CreatePostView

### DIFF
--- a/packages/app/src/components/views/publication/ArticleTabs.tsx
+++ b/packages/app/src/components/views/publication/ArticleTabs.tsx
@@ -1,0 +1,52 @@
+import { Tabs, Tab, styled } from "@mui/material"
+import React, { useEffect, useState } from "react"
+import theme from "../../../theme"
+
+const ArticleTab = styled(Tab)({
+  fontSize: "1rem",
+  paddingLeft: theme.spacing(1),
+  paddingRight: theme.spacing(1),
+  minWidth: "auto",
+})
+
+export const ARTICLE_TABS = [
+  { label: "Write", value: "write" },
+  { label: "Preview", value: "preview" },
+]
+
+type ArticleTabsProps = {
+  onChange: (tab: "write" | "preview") => void
+}
+
+const ArticleTabs: React.FC<ArticleTabsProps> = ({ onChange }) => {
+  const [currentTab, setCurrentTab] = useState<"write" | "preview">(
+    ARTICLE_TABS[0].value as "write" | "preview",
+  )
+
+  const handleChange = (event: React.SyntheticEvent, newValue: "write" | "preview") => {
+    setCurrentTab(newValue)
+  }
+
+  useEffect(() => {
+    if (currentTab) {
+      onChange(currentTab)
+    }
+  }, [onChange, currentTab])
+
+  return (
+    <Tabs
+      value={currentTab}
+      onChange={handleChange}
+      textColor="secondary"
+      indicatorColor="secondary"
+    >
+      {ARTICLE_TABS.map(({ label, value }, index) => {
+        return (
+          <ArticleTab label={label} value={value} key={index} />
+        )
+      })}
+    </Tabs>
+  )
+}
+
+export default ArticleTabs

--- a/packages/app/src/components/views/publication/CreatePostView.tsx
+++ b/packages/app/src/components/views/publication/CreatePostView.tsx
@@ -1,11 +1,13 @@
 import { Box, Button, CircularProgress, FormHelperText, Grid, styled, TextField, Typography } from "@mui/material"
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline"
-import React, { useEffect, useState } from "react"
+import React, { ChangeEvent, useEffect, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { usePublicationContext } from "../../../services/publications/contexts"
 import { palette } from "../../../theme"
 import { ViewContainer } from "../../commons/ViewContainer"
 import PublicationPage from "../../layout/PublicationPage"
+import ArticleTabs from "./ArticleTabs"
+import { Markdown } from "../../commons/Markdown"
 import * as yup from "yup"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { Article } from "../../../models/publication"
@@ -42,6 +44,8 @@ export const CreatePostView: React.FC = () => {
   )
   const { type } = useParams<{ type: "new" | "edit" }>()
   const [loading, setLoading] = useState<boolean>(false)
+  const [currentTab, setCurrentTab] = useState<"write" | "preview">("write")
+  const [articleContent, setArticleContent] = useState<string>("")
   const permissions = article && article.publication && article.publication.permissions
   const havePermissionToDelete = haveActionPermission(permissions || [], "articleDelete", account || "")
   const havePermissionToUpdate = haveActionPermission(permissions || [], "articleUpdate", account || "")
@@ -81,6 +85,10 @@ export const CreatePostView: React.FC = () => {
       navigate(-1)
     }
   }, [navigate, saveDraftArticle, transactionCompleted])
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement> ) => {
+    setArticleContent(event.target.value)
+  }
 
   const onSubmitHandler = (data: Article) => {
     saveDraftArticle(data)
@@ -150,20 +158,55 @@ export const CreatePostView: React.FC = () => {
               )}
             </Grid>
             <Grid item xs={12}>
-              <Controller
-                control={control}
-                name="article"
-                render={({ field }) => (
-                  <TextField {...field} placeholder="Start your post..." sx={{ width: "100%" }} multiline rows={14} />
-                )}
-                rules={{ required: true }}
-              />
 
-              {errors && errors.article && (
-                <FormHelperText sx={{ color: palette.secondary[1000], textTransform: "capitalize" }}>
-                  {errors.article.message}
-                </FormHelperText>
+              <ArticleTabs onChange={setCurrentTab} />
+              {currentTab === "write" && (
+                <>
+                  <Controller
+                    control={control}
+                    name="article"
+                    render={({ field }) => (
+                      <TextField
+                      {...field}
+                      placeholder="Start your post..."
+                      multiline
+                      rows={14}
+                      onChange={handleChange}
+                      value={articleContent}
+                      sx={{
+                        width: "100%",
+                        "& .MuiInputBase-root": {
+                          borderTopLeftRadius: 0,
+                        }
+                      }}
+                    />
+                    )}
+                    rules={{ required: true }}
+                  />
+    
+                  {errors && errors.article && (
+                    <FormHelperText sx={{ color: palette.secondary[1000], textTransform: "capitalize" }}>
+                      {errors.article.message}
+                    </FormHelperText>
+                  )}
+                </>
               )}
+              {currentTab === "preview" && (
+                articleContent ? (
+                  <Markdown>{articleContent}</Markdown>
+                ) : (
+                  <Box
+                    sx={{
+                      color: palette.grays[800],
+                      fontSize: 14,
+                      mt: 1
+                    }}
+                  >
+                    Nothing to preview
+                  </Box>
+                )
+              )}
+
             </Grid>
             {type === "new" && (
               <Grid item xs={12} mt={1}>


### PR DESCRIPTION
# Description

Allows the user to preview their post before publishing.

# Implementation

The current value of the text field is rendered in the preview tab.

<img width="632" alt="image" src="https://user-images.githubusercontent.com/80348806/181562756-ded8c75e-36bc-41f2-90c1-0a2b04f9f215.png">
<img width="665" alt="image" src="https://user-images.githubusercontent.com/80348806/181562902-b2644b3f-d436-4ba2-a2f4-a2b720633ae1.png">


# Additional Context

This is a bit of a makeshift fix, as it would be much better to have the default post entry as rich text (with the option to import markdown). For now though, this is a massive improvement and gives users much more clarity around what they're about to post.