### PR TITLE
add support for OPoGC

### DIFF
--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -15,6 +15,7 @@ env:
   REACT_APP_SUBGRAPH_POLYGON: auryn-macmillan/tabula-polygon
   REACT_APP_SUBGRAPH_ARBITRUM: auryn-macmillan/tabula-arbitrum
   REACT_APP_SUBGRAPH_OPTIMISM: auryn-macmillan/tabula-optimism
+  REACT_APP_SUBGRAPH_OPTIMISM: auryn-macmillan/tabula-optimism-on-gnosis-chain
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -133,6 +134,12 @@ jobs:
         env:
           HOSTED_SERVICE_SUBGRAPH__OPTIMISM: auryn-macmillan/tabula-optimism
         run: yarn deploy:optimism
+
+      - name: Deploy subgraph to Optimism on Gnosis Chain
+        working-directory: packages/subgraph
+        env:
+          HOSTED_SERVICE_SUBGRAPH__OPTIMISM__ON__GNOSIS__CHAIN: auryn-macmillan/tabula-optimism-on-gnosis-chain
+        run: yarn deploy:optimism-on-gnosis-chain
 
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@v4.3.3

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -8,3 +8,4 @@ REACT_APP_SUBGRAPH_GOERLI=auryn-macmillan/tabula-goerli
 REACT_APP_SUBGRAPH_POLYGON=auryn-macmillan/tabula-polygon
 REACT_APP_SUBGRAPH_ARBITRUM=auryn-macmillan/tabula-arbitrum
 REACT_APP_SUBGRAPH_OPTIMISM=auryn-macmillan/tabula-optimism
+REACT_APP_SUBGRAPH_OPTIMISM=auryn-macmillan/tabula-optimism-on-gnosis-chain

--- a/packages/app/src/connectors/index.ts
+++ b/packages/app/src/connectors/index.ts
@@ -21,6 +21,7 @@ const NETWORK_URLS: { [key in SupportedChainId]: string } = {
   [SupportedChainId.POLYGON]: `https://polygon-rpc.com/`,
   [SupportedChainId.ARBITRUM]: `https://arb1.arbitrum.io/rpc/`,
   [SupportedChainId.OPTIMISM]: `https://mainnet.optimism.io/`,
+  [SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN]: `https://optimism.gnosischain.com`,
 }
 
 export const network = new NetworkConnector({

--- a/packages/app/src/constants/chain.ts
+++ b/packages/app/src/constants/chain.ts
@@ -10,6 +10,7 @@ export enum SupportedChainId {
   POLYGON = 137,
   ARBITRUM = 42161,
   OPTIMISM = 10,
+  OPTIMISM_ON_GNOSIS_CHAIN = 300,
 }
 
 export enum SupportedChain {
@@ -20,6 +21,7 @@ export enum SupportedChain {
   POLYGON = "polygon",
   ARBITRUM = "arbitrum",
   OPTIMISM = "optimism",
+  OPTIMISM_ON_GNOSIS_CHAIN = "optimism_on_gnosis_chain",
 }
 
 export const chainIdToChainName = (chainId: number) => {
@@ -38,6 +40,8 @@ export const chainIdToChainName = (chainId: number) => {
       return SupportedChain.ARBITRUM
     case SupportedChainId.OPTIMISM:
       return SupportedChain.OPTIMISM
+    case SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN:
+      return SupportedChain.OPTIMISM_ON_GNOSIS_CHAIN
   }
 }
 
@@ -57,6 +61,8 @@ export const chainNameToChainId = (chainName?: string) => {
       return SupportedChainId.ARBITRUM
     case SupportedChain.OPTIMISM:
       return SupportedChainId.OPTIMISM
+    case SupportedChain.OPTIMISM_ON_GNOSIS_CHAIN:
+      return SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN
     default:
       return -1
   }
@@ -70,6 +76,7 @@ export const ALL_SUPPORTED_CHAIN_IDS: SupportedChainId[] = [
   SupportedChainId.POLYGON,
   SupportedChainId.ARBITRUM,
   SupportedChainId.OPTIMISM,
+  SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN,
 ]
 
 export const chainToString = (chainId: number) => {
@@ -88,6 +95,8 @@ export const chainToString = (chainId: number) => {
       return `Arbitrum (ChainID: ${chainId})`
     case SupportedChainId.OPTIMISM:
       return `Optimism (ChainID: ${chainId})`
+    case SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN:
+      return `Optimism on Gnosis Chain (ChainID: ${chainId})`
     default: {
       console.warn(`Missing "chainToString" implementation for ChainID: ${chainId}`)
       return "Unknown chain"
@@ -225,6 +234,18 @@ const chainParameters = (chainId: number) => {
           decimals: 18,
         },
         blockExplorerUrls: ["https://optimistic.etherscan.io/"],
+      }
+    case SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN:
+      return {
+        chainId: requiredChainIdHex,
+        chainName: "Optimism on Gnosis Chain",
+        rpcUrls: ["https://optimism.gnosischain.com"],
+        nativeCurrency: {
+          name: "xDai",
+          symbol: "xDai",
+          decimals: 18,
+        },
+        blockExplorerUrls: ["https://blockscout.com/xdai/optimism/"],
       }
   }
 }

--- a/packages/app/src/services/graphql.ts
+++ b/packages/app/src/services/graphql.ts
@@ -25,6 +25,9 @@ if (!process.env.REACT_APP_SUBGRAPH_ARBITRUM) {
 if (!process.env.REACT_APP_SUBGRAPH_OPTIMISM) {
   throw new Error("REACT_APP_SUBGRAPH_OPTIMISM is not set")
 }
+if (!process.env.REACT_APP_SUBGRAPH_OPTIMISM_ON_GNOSIS_CHAIN) {
+  throw new Error("REACT_APP_SUBGRAPH_OPTIMISM_ON_GNOSIS_CHAIN is not set")
+}
 
 const BASE_SUBGRAPH_URL = process.env.REACT_APP_SUBGRAPH_BASE_URL
 const SUBGRAPH_GNOSIS_CHAIN = process.env.REACT_APP_SUBGRAPH_GNOSIS_CHAIN
@@ -34,6 +37,7 @@ const SUBGRAPH_GOERLI = process.env.REACT_APP_SUBGRAPH_GOERLI
 const SUBGRAPH_POLYGON = process.env.REACT_APP_SUBGRAPH_POLYGON
 const SUBGRAPH_ARBITRUM = process.env.REACT_APP_SUBGRAPH_ARBITRUM
 const SUBGRAPH_OPTIMISM = process.env.REACT_APP_SUBGRAPH_OPTIMISM
+const SUBGRAPH_OPTIMISM_ON_GNOSIS_CHAIN = process.env.REACT_APP_SUBGRAPH_OPTIMISM_ON_GNOSIS_CHAIN
 
 const getUrl = (chainId?: number) => {
   switch (chainId) {
@@ -49,6 +53,8 @@ const getUrl = (chainId?: number) => {
       return BASE_SUBGRAPH_URL + SUBGRAPH_POLYGON
     case SupportedChainId.OPTIMISM:
       return BASE_SUBGRAPH_URL + SUBGRAPH_OPTIMISM
+    case SupportedChainId.OPTIMISM_ON_GNOSIS_CHAIN:
+      return BASE_SUBGRAPH_URL + SUBGRAPH_OPTIMISM_ON_GNOSIS_CHAIN
     case SupportedChainId.ARBITRUM:
       return BASE_SUBGRAPH_URL + SUBGRAPH_ARBITRUM
     default:

--- a/packages/subgraph/network_configs/optimism-on-gnosis-chain.json
+++ b/packages/subgraph/network_configs/optimism-on-gnosis-chain.json
@@ -1,0 +1,4 @@
+{
+  "network": "optimism on gnosis chain",
+  "startBlock": 1374003
+}

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -18,6 +18,8 @@
     "prepare:polygon": "mustache network_configs/polygon.json subgraph.template.yaml > subgraph.yaml",
     "deploy:optimism": "yarn prepare:optimism && bash -c 'source .env || true && graph deploy --node https://api.thegraph.com/deploy/ $HOSTED_SERVICE_SUBGRAPH__OPTIMISM'",
     "prepare:optimism": "mustache network_configs/optimism.json subgraph.template.yaml > subgraph.yaml",
+    "deploy:optimism-on-gnosis-chain": "yarn prepare:optimism-on-gnosis-chain && bash -c 'source .env || true && graph deploy --node https://api.thegraph.com/deploy/ $HOSTED_SERVICE_SUBGRAPH__OPTIMISM__ON__GNOSIS__CHAIN'",
+    "prepare:optimism": "mustache network_configs/optimism-on-gnosis-chain.json subgraph.template.yaml > subgraph.yaml",
     "deploy:arbitrum": "yarn prepare:arbitrum && bash -c 'source .env || true && graph deploy --node https://api.thegraph.com/deploy/ $HOSTED_SERVICE_SUBGRAPH__ARBITRUM'",
     "prepare:arbitrum": "mustache network_configs/arbitrum.json subgraph.template.yaml > subgraph.yaml",
     "fmt": "prettier '(test|src)/**/*.ts' -w",


### PR DESCRIPTION
# Description

This PR adds support for Optimism on Gnosis Chain

# Additional Context
Optimism on Gnosis Chain is a deployment of [Optimism](https://www.optimism.io/) on top of Gnosis Chain. You can learn more about it on the [Gnosis Chain docs](https://developers.gnosischain.com/for-developers/optimism-optimistic-rollups-on-gc).