### PR TITLE
Add users

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1,37 +1,53 @@
 type Article @entity {
   id: ID!
   publication: Publication!
-  poster: Bytes! # message sender for article creation event
-  article: String! # markdown formatted string or IPFS hash
-  authors: [String!] # array of authors (address or string name)
-  postedOn: BigInt! # unix timestamp of original article
-  lastUpdated: BigInt! # unix timestamp of last update
-  tags: [String!] # array of tags
-  title: String! # title of the article
-  description: String # description of the article
-  image: String # IPFS hash (pointing to a image) or a BASE64 encoded image string
+  poster: Bytes! # message sender for article creation event.
+  article: String! # markdown formatted string or IPFS hash.
+  authors: [String!] # array of authors (chain specific address or name).
+  postedOn: BigInt! # unix timestamp of original article.
+  lastUpdated: BigInt! # unix timestamp of last update.
+  tags: [String!] # array of tags.
+  title: String! # title of the article.
+  description: String # description of the article.
+  image: String # IPFS hash (pointing to a image) or a BASE64 encoded image string.
 }
 
 type Publication @entity {
   id: ID!
-  title: String! # title of the publication
-  description: String
-  image: String # IPFS hash (pointing to a image) or a BASE64 encoded image string
-  tags: [String!] # array of tags
-  articles: [Article!]! # articles in this publication
-  permissions: [Permission!]! # permissions in this publication
-  createdOn: BigInt! # unix timestamp
-  lastUpdated: BigInt! # unix timestamp
+  title: String! # title of the publication.
+  description: String # short description of the publication.
+  link: String # a URL to be displayed on the publication profile
+  twitter: String # the publication's twitter profile
+  github: String # the publication's github profile
+  discord: String # an invite link to the publication's discord
+  image: String # IPFS hash (pointing to an image) or a BASE64 encoded image string.
+  tags: [String!] # array of tags.
+  articles: [Article!]! # articles in this publication.
+  permissions: [Permission!]! # permissions in this publication.
+  createdOn: BigInt! # unix timestamp.
+  lastUpdated: BigInt! # unix timestamp.
 }
 
 type Permission @entity {
   id: ID!
-  publication: Publication!
-  address: Bytes!
-  articleCreate: Boolean
-  articleUpdate: Boolean
-  articleDelete: Boolean
-  publicationUpdate: Boolean
-  publicationDelete: Boolean
-  publicationPermissions: Boolean
+  publication: Publication! # the publication in which these permissions are held.
+  address: Bytes! # user address.
+  articleCreate: Boolean # can create new articles in this publication.
+  articleUpdate: Boolean # can modify existing articles in this publication.
+  articleDelete: Boolean # can delete existing articles in this publication.
+  publicationUpdate: Boolean # can modify this publication.
+  publicationDelete: Boolean # can delete this publication, along with all of its articles.
+  publicationPermissions: Boolean # can modify permissions in this publication.
+}
+
+type User @entity {
+  id: ID! # could be either a chain specific address, for a default user profile, or the concatenation of a chain specific address and a publication ID for a publication specific profile.
+  displayName: String # this user's chosen display name.
+  profilePicture: String # IPFS hash (pointing to an image) or a BASE64 encoded image string.
+  link: String # a link to be displayed on the user's profile
+  twitter: String # user's twitter handle
+  github: String # user's github handle
+  permissions: [Permission!]! # permissions that this user holds.
+  articles: [Article!]! # articles on which this user is listed as an author.
+  publications: [Publication!]! # publications in which the user has approved themself to be listed as an author.
 }


### PR DESCRIPTION
# Description

This PR adds a user entity to the subgraph. User's can have both a default profile, along with publication specific profiles associated with the same address. Profiles include these properties: `id`, `displayName`, `profilePicture`, `link`, `twitter`, `github`, `permissions`, `articles`, and `publications`.

# Implementation

A new entity, `User`, is defined in the schema.

Accounts should be able to create and modify their user profile by calling the Poster contract with a `user/update ` action. 

Accounts should be able to delete their user profiles by calling the Poster contract with a `user/delete` action.

# Additional Context

The user entity will be used initially to add richer profile information for authors. However, any user can create a profile and these could later be exposed in the app in a number of ways (likes, comments, reactions, patronage, etc). 