### PR TITLE
Fix transaction URL

### DIFF
--- a/packages/app/src/services/poster/hooks/usePoster.ts
+++ b/packages/app/src/services/poster/hooks/usePoster.ts
@@ -79,7 +79,7 @@ const usePoster = () => {
           const receipt: TransactionReceipt = await tx.wait()
           content.image && (await pinAction(content.image, `${content.title}-image`))
 
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
           setLoading(false)
         } catch (error: any) {
           setLoading(false)
@@ -101,7 +101,7 @@ const usePoster = () => {
         try {
           const tx = await poster.post(JSON.stringify(publication), PUBLICATION_TAG)
           const receipt: TransactionReceipt = await tx.wait()
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
 
           setLoading(false)
         } catch (error: any) {
@@ -145,7 +145,7 @@ const usePoster = () => {
           setLoading(false)
           content.image && (await pinAction(content.image, `${content.title}-image`, "Successfully image pinned"))
           pin && (await pinAction(content.article, `Article-${content.title}`, "Successfully article pinned"))
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
         } catch (error: any) {
           setLoading(false)
           showTransactionError()
@@ -197,7 +197,7 @@ const usePoster = () => {
               `Article-${content.title}-${content.lastUpdated}`,
               "Successfully pinned article",
             ))
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
         } catch (error: any) {
           setLoading(false)
           showTransactionError()
@@ -219,7 +219,7 @@ const usePoster = () => {
           const tx = await poster.post(JSON.stringify(content), PUBLICATION_TAG)
           const receipt: TransactionReceipt = await tx.wait()
           setLoading(false)
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
         } catch (error: any) {
           setLoading(false)
           showTransactionError()
@@ -241,7 +241,7 @@ const usePoster = () => {
           const tx = await poster.post(JSON.stringify(fields), PUBLICATION_TAG)
           const receipt: TransactionReceipt = await tx.wait()
           setLoading(false)
-          setTransactionUrl(URL + receipt.transactionHash)
+          setTransactionUrl(`${URL}tx/${receipt.transactionHash}`)
         } catch (error: any) {
           setLoading(false)
           showTransactionError()


### PR DESCRIPTION
closes #153 

# Description

The solution was already implemented, but the `URL` needed the `tx` prefix because it pointed to the proper blocker explorer without the correct parameters.

UI
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/19823989/212900716-5fa09585-e7f1-4c44-bf02-d4b755d27810.png">