### PR TITLE
Remove the use of the IPFS_GATEWAY outside of the `useIpfs`hook

### DIFF
--- a/packages/app/src/components/layout/PublicationPage.tsx
+++ b/packages/app/src/components/layout/PublicationPage.tsx
@@ -4,6 +4,7 @@ import PublicationHeader from "./PublicationHeader"
 import { Publications } from "../../models/publication"
 import { Helmet } from "react-helmet"
 import { useDynamicFavIcon } from "../../hooks/useDynamicFavIco"
+import usePublication from "../../services/publications/hooks/usePublication"
 
 type Props = {
   publication?: Publications
@@ -11,7 +12,8 @@ type Props = {
 }
 
 const PublicationPage: React.FC<Props> = ({ children, publication, showCreatePost }) => {
-  useDynamicFavIcon(publication?.image)
+  const { imageSrc } = usePublication(publication?.id || "")
+  useDynamicFavIcon(imageSrc)
   return (
     <>
       <Helmet>

--- a/packages/app/src/components/views/publication/ArticleView.tsx
+++ b/packages/app/src/components/views/publication/ArticleView.tsx
@@ -13,6 +13,7 @@ import isIPFS from "is-ipfs"
 import { WalletBadge } from "../../commons/WalletBadge"
 import { chainNameToChainId } from "../../../constants/chain"
 import { useDynamicFavIcon } from "../../../hooks/useDynamicFavIco"
+import usePublication from "../../../services/publications/hooks/usePublication"
 
 interface ArticleViewProps {
   updateChainId: (chainId: number) => void
@@ -23,8 +24,8 @@ export const ArticleView: React.FC<ArticleViewProps> = ({ updateChainId }) => {
   const { publicationId } = useParams<{ publicationId: string }>()
   const { article, saveArticle, getIpfsData, markdownArticle, setMarkdownArticle, loading } = usePublicationContext()
   const { data, executeQuery, imageSrc } = useArticle(articleId || "")
-  const publication = article?.publication
-  useDynamicFavIcon(publication?.image)
+  const publication = usePublication(article?.publication?.id || "")
+  useDynamicFavIcon(publication.imageSrc)
   const date = article && article.lastUpdated && new Date(parseInt(article.lastUpdated) * 1000)
   const isValidHash = article && isIPFS.multihash(article.article)
   const [articleToShow, setArticleToShow] = useState<string>("")

--- a/packages/app/src/components/views/publication/PublicationView.tsx
+++ b/packages/app/src/components/views/publication/PublicationView.tsx
@@ -15,8 +15,6 @@ import ArticleSection from "./components/ArticleSection"
 import PublicationTabs from "./components/PublicationTabs"
 import { SettingSection } from "./components/SettingSection"
 
-const IPFS_GATEWAY = process.env.REACT_APP_IPFS_GATEWAY
-
 const PublicationContainer = styled(Grid)(({ theme }) => ({
   [`${theme.breakpoints.down("md")}`]: {
     justifyContent: "center",
@@ -37,7 +35,7 @@ export const PublicationView: React.FC<PublicationViewProps> = ({ updateChainId 
   const { publicationId, network } = useParams<{ publicationId: string; network: string }>()
   const { account } = useWeb3React()
   const { savePublication, editingPublication, saveDraftPublicationImage } = usePublicationContext()
-  const { data: publication, loading, executeQuery } = usePublication(publicationId || "")
+  const { data: publication, loading, executeQuery, imageSrc } = usePublication(publicationId || "")
   const [currentTab, setCurrentTab] = useState<"articles" | "permissions" | "settings">("articles")
   const permissions = publication && publication.permissions
   const havePermission = permissions ? isOwner(permissions, account || "") : false
@@ -78,10 +76,7 @@ export const PublicationView: React.FC<PublicationViewProps> = ({ updateChainId 
               <PublicationContainer container gap={3} alignItems={"center"}>
                 <Grid item>
                   {!editingPublication && (
-                    <Avatar
-                      sx={{ width: 160, height: 160 }}
-                      src={publication.image ? `${IPFS_GATEWAY}/${publication.image}` : ""}
-                    >
+                    <Avatar sx={{ width: 160, height: 160 }} src={imageSrc}>
                       {" "}
                     </Avatar>
                   )}

--- a/packages/app/src/hooks/useDynamicFavIco.ts
+++ b/packages/app/src/hooks/useDynamicFavIco.ts
@@ -1,9 +1,7 @@
 import { useEffect } from "react"
 
-export const useDynamicFavIcon = (image: string | null | undefined) => {
-  const IPFS_GATEWAY = process.env.REACT_APP_IPFS_GATEWAY
-  const imageUrl = `${IPFS_GATEWAY}/${image}`
-  const favIcon = process.env.PUBLIC_URL + "/favicon.ico"
+export const useDynamicFavIcon = async (imageSrc?: string) => {
+  const defaultFavIcon = process.env.PUBLIC_URL + "/favicon.ico"
   useEffect(() => {
     let link = document.querySelector("link[rel~='icon']") as any
     if (!link) {
@@ -11,6 +9,6 @@ export const useDynamicFavIcon = (image: string | null | undefined) => {
       link.rel = "icon"
       document.getElementsByTagName("head")[0].appendChild(link)
     }
-    link.href = image ? imageUrl : favIcon
-  }, [favIcon, image, imageUrl])
+    link.href = imageSrc ?? defaultFavIcon
+  }, [defaultFavIcon, imageSrc])
 }


### PR DESCRIPTION
Remove the use of the IPFS_GATEWAY outside of the `useIpfs`hook.

We should not use `IPFS_GATEWAY` directly, since in the future that will be removed.