### PR TITLE
Ens resolution

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -25,7 +25,7 @@
     "@web3-react/walletlink-connector": "^6.2.13",
     "axios": "^0.26.1",
     "blockies-ts": "^1.0.0",
-    "ethers": "^5.6.1",
+    "ethers": "^5.7.2",
     "gh-pages": "^3.2.3",
     "graphql": "^16.3.0",
     "ipfs-core": "0.14.3",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -49,29 +49,21 @@ const App: React.FC = () => {
               <ScrollToTop />
               <Routes>
                 {" "}
-                {/* Common routes  */}
                 <Route path="/" element={<LandingView />} />
                 <Route path="/wallet" element={<WalletView />} />
                 <Route path="/pinning" element={<SetupIpfsView />} />
-                <Route path="/:network/publications" element={<PublicationsView updateChainId={updateChainId} />} />
-                {/* Raw routes  */}
-                <Route path="/:network/publications">
-                  <Route path=":publicationId" element={<PublicationView updateChainId={updateChainId} />} />
-                  <Route path=":publicationId">
-                    <Route path="permissions/:type" element={<PermissionView />} />
+                <Route path="/publications" element={<PublicationsView updateChainId={updateChainId} />} />
+                <Route path=":publicationSlug" element={<PublicationView updateChainId={updateChainId} />} />
+                <Route path=":publicationSlug">
+                  <Route path="permissions/:type" element={<PermissionView />} />
 
-                    <Route path="new" element={<CreateArticleView type="new" />} />
-                    <Route path="new/2" element={<CreateArticleView2 type="new" />} />
+                  <Route path="new" element={<CreateArticleView type="new" />} />
+                  <Route path="new/2" element={<CreateArticleView2 type="new" />} />
 
-                    <Route path=":articleId" element={<ArticleView updateChainId={updateChainId} />} />
+                  <Route path=":articleId" element={<ArticleView updateChainId={updateChainId} />} />
 
-                    <Route path=":articleId/edit" element={<CreateArticleView type="edit" />} />
-                    <Route path=":articleId/edit/2" element={<CreateArticleView2 type="edit" />} />
-                  </Route>
-                </Route>
-                {/* ENS routes (should look nice) */}
-                <Route path="/:publicationEns" element={<PublicationView updateChainId={updateChainId} />}>
-                  <Route path=":articleId" element={<PublicationView updateChainId={updateChainId} />} />
+                  <Route path=":articleId/edit" element={<CreateArticleView type="edit" />} />
+                  <Route path=":articleId/edit/2" element={<CreateArticleView2 type="edit" />} />
                 </Route>
               </Routes>
             </PosterProvider>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -18,6 +18,7 @@ import SetupIpfsView from "./components/views/pinning/SetupIpfsView"
 import { useWeb3React } from "@web3-react/core"
 import { PosterProvider } from "./services/poster/context"
 import { WalletProvider } from "./connectors/WalletProvider"
+import { RedirectOldRoute } from "./components/commons/RedicrectOldRoute"
 
 const App: React.FC = () => {
   // the chainId should be from the publication if its present
@@ -54,6 +55,14 @@ const App: React.FC = () => {
                 <Route path="/pinning" element={<SetupIpfsView />} />
                 <Route path="/publications" element={<PublicationsView updateChainId={updateChainId} />} />
                 <Route path=":publicationSlug" element={<PublicationView updateChainId={updateChainId} />} />
+                {/* Redirect old routes to new routes */}
+                <Route path="/goerli/*" element={<RedirectOldRoute />} />
+                <Route path="/mainnet/*" element={<RedirectOldRoute />} />
+                <Route path="/gnosis_chain/*" element={<RedirectOldRoute />} />
+                <Route path="/polygon/*" element={<RedirectOldRoute />} />
+                <Route path="/arbitrum/*" element={<RedirectOldRoute />} />
+                <Route path="/optimism/*" element={<RedirectOldRoute />} />
+                {/* New routes */}
                 <Route path=":publicationSlug">
                   <Route path="permissions/:type" element={<PermissionView />} />
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -48,16 +48,30 @@ const App: React.FC = () => {
             <PosterProvider>
               <ScrollToTop />
               <Routes>
+                {" "}
+                {/* Common routes  */}
                 <Route path="/" element={<LandingView />} />
                 <Route path="/wallet" element={<WalletView />} />
-                <Route path="/:network">
-                  <Route path="pinning" element={<SetupIpfsView />} />
-                  <Route path="publications" element={<PublicationsView updateChainId={updateChainId} />} />
+                <Route path="/pinning" element={<SetupIpfsView />} />
+                <Route path="/:network/publications" element={<PublicationsView updateChainId={updateChainId} />} />
+                {/* Raw routes  */}
+                <Route path="/:network/publications">
                   <Route path=":publicationId" element={<PublicationView updateChainId={updateChainId} />} />
-                  <Route path=":publicationId/:postId/:type" element={<CreateArticleView />} />
-                  <Route path=":publicationId/:postId/preview/:type" element={<CreateArticleView2 />} />
-                  <Route path=":publicationId/:articleId" element={<ArticleView updateChainId={updateChainId} />} />
-                  <Route path=":publicationId/permissions/:type" element={<PermissionView />} />
+                  <Route path=":publicationId">
+                    <Route path="permissions/:type" element={<PermissionView />} />
+
+                    <Route path="new" element={<CreateArticleView type="new" />} />
+                    <Route path="new/2" element={<CreateArticleView2 type="new" />} />
+
+                    <Route path=":articleId" element={<ArticleView updateChainId={updateChainId} />} />
+
+                    <Route path=":articleId/edit" element={<CreateArticleView type="edit" />} />
+                    <Route path=":articleId/edit/2" element={<CreateArticleView2 type="edit" />} />
+                  </Route>
+                </Route>
+                {/* ENS routes (should look nice) */}
+                <Route path="/:publicationEns" element={<PublicationView updateChainId={updateChainId} />}>
+                  <Route path=":articleId" element={<PublicationView updateChainId={updateChainId} />} />
                 </Route>
               </Routes>
             </PosterProvider>

--- a/packages/app/src/components/commons/PinningAlert.tsx
+++ b/packages/app/src/components/commons/PinningAlert.tsx
@@ -55,7 +55,7 @@ export const PinningAlert: React.FC = () => {
               fontWeight={700}
               color={palette.secondary[1000]}
               onClick={() => {
-                navigate("../pinning")
+                navigate("/pinning")
                 setCurrentPath(location.pathname)
               }}
             >

--- a/packages/app/src/components/commons/RedicrectOldRoute.tsx
+++ b/packages/app/src/components/commons/RedicrectOldRoute.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react"
+import { useNavigate, useLocation } from "react-router-dom"
+import { chainNameToChainId } from "../../constants/chain"
+
+export const RedirectOldRoute: React.FC = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const chainName = location.pathname.split("/")[1]
+  const chainId = chainNameToChainId(chainName)
+  console.log(chainName, chainId)
+  const newPath = location.pathname.replace(chainName + "/", chainId + "-")
+
+  useEffect(() => {
+    navigate(newPath, { replace: true })
+  })
+
+  return <></>
+}

--- a/packages/app/src/components/commons/UserOptions.tsx
+++ b/packages/app/src/components/commons/UserOptions.tsx
@@ -67,7 +67,8 @@ export const UserOptions: React.FC = () => {
         item
         sx={{ cursor: "pointer" }}
         onClick={() => {
-          navigate("../publications")
+          const network = location.pathname.split("/")[1] // TODO: can take network from here. What if its a ENS name?
+          navigate(`/${network}/publications`)
         }}
       >
         <Grid container gap={1} alignItems="center">

--- a/packages/app/src/components/commons/UserOptions.tsx
+++ b/packages/app/src/components/commons/UserOptions.tsx
@@ -43,7 +43,7 @@ export const UserOptions: React.FC = () => {
         sx={{ cursor: "pointer" }}
         onClick={() => {
           setCurrentPath(location.pathname)
-          navigate("../pinning")
+          navigate("/pinning")
         }}
       >
         <Grid container gap={1} alignItems="center">
@@ -67,8 +67,7 @@ export const UserOptions: React.FC = () => {
         item
         sx={{ cursor: "pointer" }}
         onClick={() => {
-          const network = location.pathname.split("/")[1] // TODO: can take network from here. What if its a ENS name?
-          navigate(`/${network}/publications`)
+          navigate(`/publications`)
         }}
       >
         <Grid container gap={1} alignItems="center">

--- a/packages/app/src/components/layout/PublicationHeader.tsx
+++ b/packages/app/src/components/layout/PublicationHeader.tsx
@@ -53,7 +53,8 @@ const PublicationHeader: React.FC<Props> = ({ publication, showCreatePost }) => 
     refetch()
     saveDraftArticle(undefined)
     saveArticle(undefined)
-    navigate(`../${publication?.id}`)
+    const network = location.pathname.split("/")[1]
+    navigate(`/${network}/publications/${publication?.id}`)
   }
 
   return (
@@ -126,7 +127,7 @@ const PublicationHeader: React.FC<Props> = ({ publication, showCreatePost }) => 
                   variant="contained"
                   size={"large"}
                   onClick={() => {
-                    navigate(`../${publication?.id}/new-article/new`)
+                    navigate(`./new`)
                   }}
                 >
                   <AddIcon style={{ marginRight: 13 }} />

--- a/packages/app/src/components/layout/PublicationHeader.tsx
+++ b/packages/app/src/components/layout/PublicationHeader.tsx
@@ -5,7 +5,7 @@ import { WalletBadge } from "../commons/WalletBadge"
 import { Publications } from "../../models/publication"
 import AddIcon from "@mui/icons-material/Add"
 import theme, { palette, typography } from "../../theme"
-import { useLocation, useNavigate } from "react-router-dom"
+import { useLocation, useNavigate, useParams } from "react-router-dom"
 import usePublication from "../../services/publications/hooks/usePublication"
 import { haveActionPermission } from "../../utils/permission"
 import { usePublicationContext } from "../../services/publications/contexts"
@@ -26,11 +26,12 @@ const ItemContainer = styled(Grid)({
   },
 })
 const PublicationHeader: React.FC<Props> = ({ publication, showCreatePost }) => {
+  const { publicationSlug } = useParams<{ publicationSlug: string }>()
   const { account, active } = useWeb3React()
   const navigate = useNavigate()
   const location = useLocation()
   const { setCurrentPath, saveDraftArticle, saveArticle } = usePublicationContext()
-  const { refetch, chainId: publicationChainId } = usePublication(publication?.id || "")
+  const { refetch, chainId: publicationChainId } = usePublication(publicationSlug || "")
   const [show, setShow] = useState<boolean>(false)
   const permissions = publication && publication.permissions
   const { imageSrc } = usePublication(publication?.id || "")
@@ -53,8 +54,7 @@ const PublicationHeader: React.FC<Props> = ({ publication, showCreatePost }) => 
     refetch()
     saveDraftArticle(undefined)
     saveArticle(undefined)
-    const network = location.pathname.split("/")[1]
-    navigate(`/${network}/publications/${publication?.id}`)
+    navigate(`/${publicationSlug}`)
   }
 
   return (

--- a/packages/app/src/components/views/pinning/SetupIpfsView.tsx
+++ b/packages/app/src/components/views/pinning/SetupIpfsView.tsx
@@ -102,7 +102,7 @@ const SetupIpfsView: React.FC = () => {
       setCurrentPath(undefined)
       return
     }
-    navigate("../publications")
+    navigate("/publications")
   }
 
   const handleClose = () => {
@@ -113,7 +113,7 @@ const SetupIpfsView: React.FC = () => {
     }
 
     if (!currentPath) {
-      navigate("../publications")
+      navigate("/publications")
       return
     }
     if (!currentPath && !showModal) {

--- a/packages/app/src/components/views/publication/ArticleView.tsx
+++ b/packages/app/src/components/views/publication/ArticleView.tsx
@@ -11,7 +11,6 @@ import { ViewContainer } from "../../commons/ViewContainer"
 import PublicationPage from "../../layout/PublicationPage"
 import isIPFS from "is-ipfs"
 import { WalletBadge } from "../../commons/WalletBadge"
-import { chainNameToChainId } from "../../../constants/chain"
 import { useDynamicFavIcon } from "../../../hooks/useDynamicFavIco"
 import usePublication from "../../../services/publications/hooks/usePublication"
 
@@ -20,8 +19,7 @@ interface ArticleViewProps {
 }
 
 export const ArticleView: React.FC<ArticleViewProps> = ({ updateChainId }) => {
-  const { articleId, network } = useParams<{ articleId: string; network: string }>()
-  const { publicationId } = useParams<{ publicationId: string }>()
+  const { articleId } = useParams<{ articleId: string }>()
   const { article, saveArticle, getIpfsData, markdownArticle, setMarkdownArticle, loading } = usePublicationContext()
   const { data, executeQuery, imageSrc } = useArticle(articleId || "")
   const publication = usePublication(article?.publication?.id || "")
@@ -30,10 +28,10 @@ export const ArticleView: React.FC<ArticleViewProps> = ({ updateChainId }) => {
   const isValidHash = article && isIPFS.multihash(article.article)
   const [articleToShow, setArticleToShow] = useState<string>("")
   useEffect(() => {
-    if (publicationId != null) {
-      updateChainId(chainNameToChainId(network))
+    if (publication.chainId != null) {
+      updateChainId(publication.chainId)
     }
-  }, [publicationId, updateChainId, network])
+  }, [publication, updateChainId])
 
   useEffect(() => {
     if (!article && articleId) {

--- a/packages/app/src/components/views/publication/CreateArticleView.tsx
+++ b/packages/app/src/components/views/publication/CreateArticleView.tsx
@@ -11,7 +11,7 @@ import { Markdown } from "../../commons/Markdown"
 import * as yup from "yup"
 import { yupResolver } from "@hookform/resolvers/yup"
 import { Article } from "../../../models/publication"
-import { useNavigate, useParams } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 import { useWeb3React } from "@web3-react/core"
 import { haveActionPermission } from "../../../utils/permission"
 import usePoster from "../../../services/poster/hooks/usePoster"
@@ -33,7 +33,11 @@ const DeleteArticleButton = styled(Button)({
   },
 })
 
-export const CreateArticleView: React.FC = () => {
+interface CreateArticleViewProps {
+  type: "new" | "edit"
+}
+
+export const CreateArticleView: React.FC<CreateArticleViewProps> = ({ type }) => {
   const navigate = useNavigate()
   const { account } = useWeb3React()
   const { deleteArticle } = usePoster()
@@ -42,7 +46,6 @@ export const CreateArticleView: React.FC = () => {
   const { indexing, setExecutePollInterval, transactionCompleted, setCurrentArticleId } = usePublication(
     publication?.id || "",
   )
-  const { type } = useParams<{ type: "new" | "edit" }>()
   const [loading, setLoading] = useState<boolean>(false)
   const [currentTab, setCurrentTab] = useState<"write" | "preview">("write")
   const permissions = article && article.publication && article.publication.permissions
@@ -91,8 +94,7 @@ export const CreateArticleView: React.FC = () => {
 
   const onSubmitHandler = (data: Article) => {
     saveDraftArticle(data)
-    const articleId = article?.id || "new"
-    navigate(`../${publication?.id}/${articleId}/preview/${type}`)
+    navigate(`./2`)
   }
 
   const handleDeleteArticle = async () => {

--- a/packages/app/src/components/views/publication/CreateArticleView2.tsx
+++ b/packages/app/src/components/views/publication/CreateArticleView2.tsx
@@ -4,7 +4,7 @@ import { usePublicationContext } from "../../../services/publications/contexts"
 import { palette, typography } from "../../../theme"
 import { ViewContainer } from "../../commons/ViewContainer"
 import PublicationPage from "../../layout/PublicationPage"
-import { useNavigate, useParams } from "react-router-dom"
+import { useNavigate } from "react-router-dom"
 import { UploadFile } from "../../commons/UploadFile"
 import { Controller, useForm } from "react-hook-form"
 import { useIpfs } from "../../../hooks/useIpfs"
@@ -19,11 +19,14 @@ import { CreatableSelect } from "../../commons/CreatableSelect"
 import { CreateSelectOption } from "../../../models/dropdown"
 import ArrowBackIcon from "@mui/icons-material/ArrowBack"
 
-export const CreateArticleView2: React.FC = () => {
+interface CreateArticleViewProps {
+  type: "new" | "edit"
+}
+
+export const CreateArticleView2: React.FC<CreateArticleViewProps> = ({ type }) => {
   const navigate = useNavigate()
 
   const { account } = useWeb3React()
-  const { type } = useParams<{ type: "new" | "edit" }>()
   const { publication, article, draftArticle, saveDraftArticle } = usePublicationContext()
   const [pinning] = useLocalStorage<Pinning | undefined>("pinning", undefined)
   const [tags, setTags] = useState<string[]>([])

--- a/packages/app/src/components/views/publication/PublicationView.tsx
+++ b/packages/app/src/components/views/publication/PublicationView.tsx
@@ -2,7 +2,6 @@ import { Avatar, Box, CircularProgress, Grid, Stack, Typography } from "@mui/mat
 import { useWeb3React } from "@web3-react/core"
 import React, { useEffect, useState } from "react"
 import { useParams } from "react-router-dom"
-import { chainNameToChainId } from "../../../constants/chain"
 import { usePublicationContext } from "../../../services/publications/contexts"
 import usePublication from "../../../services/publications/hooks/usePublication"
 import { palette, typography } from "../../../theme"
@@ -20,10 +19,18 @@ interface PublicationViewProps {
 }
 
 export const PublicationView: React.FC<PublicationViewProps> = ({ updateChainId }) => {
-  const { publicationId, network } = useParams<{ publicationId: string; network: string }>()
+  console.log("PublicationView")
+  const { publicationSlug } = useParams<{ publicationSlug: string }>()
   const { account } = useWeb3React()
   const { savePublication, editingPublication, saveDraftPublicationImage } = usePublicationContext()
-  const { data: publication, loading, executeQuery, imageSrc } = usePublication(publicationId || "")
+  const {
+    data: publication,
+    loading,
+    executeQuery,
+    imageSrc,
+    publicationId,
+    chainId,
+  } = usePublication(publicationSlug || "")
   const [currentTab, setCurrentTab] = useState<"articles" | "permissions" | "settings">("articles")
   const permissions = publication && publication.permissions
   const havePermission = permissions ? isOwner(permissions, account || "") : false
@@ -35,11 +42,13 @@ export const PublicationView: React.FC<PublicationViewProps> = ({ updateChainId 
     : false
 
   useEffect(() => {
-    updateChainId(chainNameToChainId(network))
-  }, [network, updateChainId])
+    if (chainId != null) {
+      updateChainId(chainId)
+    }
+  }, [chainId, updateChainId])
 
   useEffect(() => {
-    if (publicationId) {
+    if (publicationId != null) {
       executeQuery()
     }
   }, [publicationId, executeQuery])

--- a/packages/app/src/components/views/publication/PublicationView.tsx
+++ b/packages/app/src/components/views/publication/PublicationView.tsx
@@ -19,7 +19,6 @@ interface PublicationViewProps {
 }
 
 export const PublicationView: React.FC<PublicationViewProps> = ({ updateChainId }) => {
-  console.log("PublicationView")
   const { publicationSlug } = useParams<{ publicationSlug: string }>()
   const { account } = useWeb3React()
   const { savePublication, editingPublication, saveDraftPublicationImage } = usePublicationContext()

--- a/packages/app/src/components/views/publication/PublicationsView.tsx
+++ b/packages/app/src/components/views/publication/PublicationsView.tsx
@@ -190,7 +190,7 @@ export const PublicationsView: React.FC<PublicationsViewProps> = ({ updateChainI
                   <PublicationItem
                     publication={publication}
                     key={publication.id}
-                    onClick={() => navigate(`../${publication.id}`)}
+                    onClick={() => navigate(`./${publication.id}`)}
                   />
                 ))}
               </Grid>

--- a/packages/app/src/components/views/publication/PublicationsView.tsx
+++ b/packages/app/src/components/views/publication/PublicationsView.tsx
@@ -18,7 +18,6 @@ import usePublications from "../../../services/publications/hooks/usePublication
 import { CreatableSelect } from "../../commons/CreatableSelect"
 import { CreateSelectOption } from "../../../models/dropdown"
 import { usePosterContext } from "../../../services/poster/context"
-import { chainIdToChainName } from "../../../constants/chain"
 import { useDynamicFavIcon } from "../../../hooks/useDynamicFavIco"
 
 const PublicationsAvatarContainer = styled(Grid)(({ theme }) => ({
@@ -100,15 +99,14 @@ export const PublicationsView: React.FC<PublicationsViewProps> = ({ updateChainI
   })
 
   useEffect(() => {
-    setLastPathWithChainName(undefined)
-  }, [setLastPathWithChainName])
+    if (chainId != null) {
+      updateChainId(chainId)
+    }
+  }, [chainId, updateChainId])
 
   useEffect(() => {
-    if (chainId != null) {
-      const chainName = chainIdToChainName(chainId)
-      navigate(`/${chainName}/publications`)
-    }
-  }, [chainId, updateChainId, navigate])
+    setLastPathWithChainName(undefined)
+  }, [setLastPathWithChainName])
 
   useEffect(() => {
     if (!publications) {
@@ -190,7 +188,7 @@ export const PublicationsView: React.FC<PublicationsViewProps> = ({ updateChainI
                   <PublicationItem
                     publication={publication}
                     key={publication.id}
-                    onClick={() => navigate(`./${publication.id}`)}
+                    onClick={() => navigate(`/${publication.id}`)} // TODO: when we have reverse lookup (ens name set in the subgraph by somebody with permission) we can use that here
                   />
                 ))}
               </Grid>

--- a/packages/app/src/components/views/publication/components/ArticleItem.tsx
+++ b/packages/app/src/components/views/publication/components/ArticleItem.tsx
@@ -161,7 +161,7 @@ const ArticleItem: React.FC<ArticleItemProps> = ({ article, couldUpdate, couldDe
                         onClick={(e) => {
                           e.preventDefault()
                           e.stopPropagation()
-                          navigate(`../${publicationId}/${id}/edit`)
+                          navigate(`./${id}/edit`)
                           saveArticle(article)
                         }}
                         variant="contained"

--- a/packages/app/src/components/views/publication/components/ArticleItem.tsx
+++ b/packages/app/src/components/views/publication/components/ArticleItem.tsx
@@ -61,7 +61,6 @@ const ArticleItem: React.FC<ArticleItemProps> = ({ article, couldUpdate, couldDe
   const articleTitle = shortTitle(title, 30)
   const articleDescription = description && shortTitle(description, 165)
   const date = lastUpdated && new Date(parseInt(lastUpdated) * 1000)
-  const publicationId = article.publication?.id
   const [loading, setLoading] = useState<boolean>(false)
 
   useEffect(() => {
@@ -94,7 +93,7 @@ const ArticleItem: React.FC<ArticleItemProps> = ({ article, couldUpdate, couldDe
   return (
     <ArticleItemContainer
       onClick={() => {
-        navigate(`../${publicationId}/${id}`)
+        navigate(`./${id}`)
         saveArticle(article)
       }}
     >
@@ -201,7 +200,7 @@ const ArticleItem: React.FC<ArticleItemProps> = ({ article, couldUpdate, couldDe
                 endIcon={<ArrowForwardIosIcon sx={{ width: 16, height: 16 }} />}
                 disabled={loading || indexing}
                 onClick={() => {
-                  navigate(`../${publicationId}/${id}`)
+                  navigate(`./${id}`)
                   saveArticle(article)
                 }}
               >

--- a/packages/app/src/components/views/publication/components/ArticleSection.tsx
+++ b/packages/app/src/components/views/publication/components/ArticleSection.tsx
@@ -11,8 +11,8 @@ import ArticleItem from "./ArticleItem"
 const ArticleSection: React.FC = () => {
   const navigate = useNavigate()
   const { account } = useWeb3React()
-  const { publicationId } = useParams<{ publicationId: string }>()
-  const { data, refetch } = usePublication(publicationId ?? "")
+  const { publicationSlug } = useParams<{ publicationSlug: string }>()
+  const { data, refetch, publicationId } = usePublication(publicationSlug ?? "")
   const articles = data && data.articles
   const permissions = data && data.permissions
   const havePermissionToCreate = permissions ? haveActionPermission(permissions, "articleCreate", account || "") : false

--- a/packages/app/src/components/views/publication/components/ArticleSection.tsx
+++ b/packages/app/src/components/views/publication/components/ArticleSection.tsx
@@ -40,7 +40,7 @@ const ArticleSection: React.FC = () => {
         </Grid>
         {havePermissionToCreate && (
           <Grid item>
-            <Button variant="contained" size="medium" onClick={() => navigate(`new-article/new`)}>
+            <Button variant="contained" size="medium" onClick={() => navigate(`new`)}>
               <AddIcon style={{ marginRight: 13 }} />
               New Article
             </Button>

--- a/packages/app/src/components/views/publication/components/PermissionSection.tsx
+++ b/packages/app/src/components/views/publication/components/PermissionSection.tsx
@@ -49,14 +49,14 @@ export const PermissionSection: React.FC = () => {
                 showRemove={usersPermissions.length > 1}
                 onClick={() => {
                   savePermission(permission)
-                  navigate(`../${publication?.id}/permissions/edit`)
+                  navigate(`./permissions/edit`)
                 }}
               />
             </Grid>
           ))}
         {havePermissionToEdit && (
           <Stack
-            onClick={() => navigate(`../${publication?.id}/permissions/new`)}
+            onClick={() => navigate(`./permissions/new`)}
             direction="row"
             sx={{
               alignItems: "center",

--- a/packages/app/src/components/views/wallet/WalletView.tsx
+++ b/packages/app/src/components/views/wallet/WalletView.tsx
@@ -57,10 +57,10 @@ export const WalletView: React.FC = () => {
         if (connector != null) {
           const { name: networkName } = await getNetwork(connector)
           if (currentPath && !pinning) {
-            navigate(`/${networkName}/pinning`)
+            navigate(`/pinning`)
           }
           if (!currentPath && !pinning) {
-            navigate(`/${networkName}/pinning`)
+            navigate(`/pinning`)
           }
           if (!currentPath && pinning) {
             navigate(`/${networkName}/publications`)

--- a/packages/app/src/components/views/wallet/WalletView.tsx
+++ b/packages/app/src/components/views/wallet/WalletView.tsx
@@ -55,7 +55,6 @@ export const WalletView: React.FC = () => {
     if (active) {
       const doNavigation = async () => {
         if (connector != null) {
-          const { name: networkName } = await getNetwork(connector)
           if (currentPath && !pinning) {
             navigate(`/pinning`)
           }
@@ -63,7 +62,7 @@ export const WalletView: React.FC = () => {
             navigate(`/pinning`)
           }
           if (!currentPath && pinning) {
-            navigate(`/${networkName}/publications`)
+            navigate(`/publications`)
           }
         }
       }

--- a/packages/app/src/connectors/index.ts
+++ b/packages/app/src/connectors/index.ts
@@ -4,7 +4,7 @@ import { WalletConnectConnector } from "@web3-react/walletconnect-connector"
 import { WalletLinkConnector } from "@web3-react/walletlink-connector"
 import TABULA_LOGO_URL from "../assets/images/tabula-logo-wordmark.svg"
 
-const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
+export const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
 
 if (typeof INFURA_KEY === "undefined") {
   throw new Error(`REACT_APP_INFURA_KEY must be a defined environment variable`)

--- a/packages/app/src/services/ens.ts
+++ b/packages/app/src/services/ens.ts
@@ -13,18 +13,30 @@ const abiRegistry = [
 
 const abiImplementation = ["function ownerOf(uint256 tokenId) public view returns (address owner)"]
 
+const getTextRecordContentInfura = async (ensName: string, textRecordKey: string) => {
+  const provider = new ethers.providers.InfuraProvider("mainnet", INFURA_KEY)
+  const resolver = await provider.getResolver(ensName)
+  return resolver?.getText(textRecordKey)
+}
+
 export const getTextRecordContent = async (
-  provider: ethers.providers.BaseProvider,
   ensName: string,
   textRecordKey: string,
+  provider?: ethers.providers.BaseProvider,
 ) => {
+  // no connected wallet
+  if (provider == null) {
+    return getTextRecordContentInfura(ensName, textRecordKey)
+  }
+
   try {
+    // try to use connected provider
     const resolver = await provider.getResolver(ensName)
     return resolver?.getText(textRecordKey)
   } catch (e) {
-    const provider = new ethers.providers.InfuraProvider("mainnet", INFURA_KEY)
-    const resolver = await provider.getResolver(ensName)
-    return resolver?.getText(textRecordKey)
+    // fallback to infura
+    // we are here if ENS is not supported on the current selected network
+    return getTextRecordContentInfura(ensName, textRecordKey)
   }
 }
 

--- a/packages/app/src/services/ens.ts
+++ b/packages/app/src/services/ens.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers"
+import { INFURA_KEY } from "../connectors"
 
 const ensRegistry = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" // ENS: Registry with Fallback (singleton same address on different chains)
 const ensImplementation = "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85" // ENS: Base Registrar Implementation (singleton same address on different chains)
@@ -12,8 +13,29 @@ const abiRegistry = [
 
 const abiImplementation = ["function ownerOf(uint256 tokenId) public view returns (address owner)"]
 
-export const getTextRecordContent = (provider: ethers.providers.BaseProvider, ensName: string, textRecordKey: string) =>
-  provider.getResolver(ensName).then((resolver) => resolver?.getText(textRecordKey))
+export const getTextRecordContent = async (
+  provider: ethers.providers.BaseProvider,
+  ensName: string,
+  textRecordKey: string,
+) => {
+  try {
+    const resolver = await provider.getResolver(ensName)
+    return resolver?.getText(textRecordKey)
+  } catch (e) {
+    const provider = new ethers.providers.InfuraProvider("mainnet", INFURA_KEY)
+    const resolver = await provider.getResolver(ensName)
+    return resolver?.getText(textRecordKey)
+  }
+}
+
+export const lookupAddress = async (provider: any, address: string) => {
+  try {
+    const web3Provider = new ethers.providers.Web3Provider(provider)
+    return await web3Provider.lookupAddress(address)
+  } catch (e) {
+    console.log("ENS is not supported on this network")
+  }
+}
 
 /**
  * This only works for ENS names using a resolver that conforms to the `abiPublicResolver` (like the PublicResolver).

--- a/packages/app/src/services/ens.ts
+++ b/packages/app/src/services/ens.ts
@@ -1,0 +1,51 @@
+import { ethers } from "ethers"
+
+const ensRegistry = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" // ENS: Registry with Fallback (singleton same address on different chains)
+const ensImplementation = "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85" // ENS: Base Registrar Implementation (singleton same address on different chains)
+
+const abiPublicResolver = ["function setText(bytes32 node, string calldata key, string calldata value) external"]
+
+const abiRegistry = [
+  "function owner(bytes32 node) external view returns (address)",
+  "function resolver(bytes32 node) external view returns (address)",
+]
+
+const abiImplementation = ["function ownerOf(uint256 tokenId) public view returns (address owner)"]
+
+export const getTextRecordContent = (provider: ethers.providers.BaseProvider, ensName: string, textRecordKey: string) =>
+  provider.getResolver(ensName).then((resolver) => resolver?.getText(textRecordKey))
+
+/**
+ * This only works for ENS names using a resolver that conforms to the `abiPublicResolver` (like the PublicResolver).
+ */
+export const setTextRecord = async (
+  provider: ethers.providers.BaseProvider,
+  ensName: string,
+  key: string,
+  content: string,
+): Promise<any> => {
+  const ensRegistryContract = new ethers.Contract(ensRegistry, abiRegistry, provider)
+  const nameHash = ethers.utils.namehash(ensName)
+  const ensResolver = await ensRegistryContract.resolver(nameHash)
+  const ensResolverContract = new ethers.Contract(ensResolver, abiPublicResolver, provider)
+  return await ensResolverContract.setText(nameHash, key, content)
+}
+
+// the owner of the NFT
+export const checkIfIsOwner = async (provider: ethers.providers.Provider, ensName: string, address: string) => {
+  const BigNumber = ethers.BigNumber
+  const name = ensName.split(".")[0] // only supports toplevel
+  const labelHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(name))
+  const tokenId = BigNumber.from(labelHash).toString()
+  const ensImplementationContract = new ethers.Contract(ensImplementation, abiImplementation, provider)
+  const nftOwner = await ensImplementationContract.ownerOf(tokenId)
+  return ethers.utils.getAddress(nftOwner) === ethers.utils.getAddress(address)
+}
+
+export const checkIfIsController = async (provider: ethers.providers.Provider, ensName: string, address: string) => {
+  const ensRegistryContract = new ethers.Contract(ensRegistry, abiRegistry, provider)
+  const nameHash = ethers.utils.namehash(ensName)
+  const owner = await ensRegistryContract.owner(nameHash)
+
+  return ethers.utils.getAddress(address) === ethers.utils.getAddress(owner)
+}

--- a/packages/app/src/services/publications/hooks/usePublication.ts
+++ b/packages/app/src/services/publications/hooks/usePublication.ts
@@ -35,10 +35,8 @@ const usePublication = (publicationSlug: string) => {
 
   useEffect(() => {
     const getTabulaEnsRecord = async () => {
-      if (signer?.provider != null) {
-        const publicationId = await getTextRecordContent(signer?.provider, publicationSlug, "tabula")
-        setPublicationId(publicationId)
-      }
+      const publicationId = await getTextRecordContent(publicationSlug, "tabula", signer?.provider)
+      setPublicationId(publicationId)
     }
 
     if (publicationSlug.endsWith(".eth")) {

--- a/packages/app/src/services/publications/hooks/usePublication.ts
+++ b/packages/app/src/services/publications/hooks/usePublication.ts
@@ -1,18 +1,22 @@
 import { find, isEqual } from "lodash"
 import { useCallback, useEffect, useState } from "react"
-import { useParams } from "react-router-dom"
 import { useQuery } from "urql"
-import { chainNameToChainId } from "../../../constants/chain"
+import { SupportedChainId } from "../../../constants/chain"
 import { useIpfs } from "../../../hooks/useIpfs"
 import { useNotification } from "../../../hooks/useNotification"
+import { useWallet } from "../../../hooks/useWallet"
 import { Permission, Publications } from "../../../models/publication"
+import { getTextRecordContent } from "../../ens"
 import { usePosterContext } from "../../poster/context"
 import { usePublicationContext } from "../contexts"
 import { GET_PUBLICATION_QUERY } from "../queries"
 
-const usePublication = (id: string) => {
-  const { network } = useParams<{ network: string }>()
-  const chainId = chainNameToChainId(network)
+/**
+ * @param  {string} publicationSlug - publication id or ens name
+ **/
+const usePublication = (publicationSlug: string) => {
+  const [chainId, setChainId] = useState<SupportedChainId>()
+  const [publicationId, setPublicationId] = useState<string>()
   const openNotification = useNotification()
   const { transactionUrl } = usePosterContext()
   const { publication, permission, savePublication } = usePublicationContext()
@@ -27,6 +31,29 @@ const usePublication = (id: string) => {
   const [currentArticleId, setCurrentArticleId] = useState<string>()
   const [imageSrc, setImageSrc] = useState<string>("")
   const ipfs = useIpfs()
+  const { signer } = useWallet()
+
+  useEffect(() => {
+    const getTabulaEnsRecord = async () => {
+      if (signer?.provider != null) {
+        const publicationId = await getTextRecordContent(signer?.provider, publicationSlug, "tabula")
+        setPublicationId(publicationId)
+      }
+    }
+
+    if (publicationSlug.endsWith(".eth")) {
+      getTabulaEnsRecord()
+    } else {
+      setPublicationId(publicationSlug)
+    }
+  }, [publicationSlug, signer?.provider])
+
+  useEffect(() => {
+    if (publicationId != null) {
+      const chainId = getPublicationChainId(publicationId)
+      setChainId(chainId as SupportedChainId)
+    }
+  }, [publicationId])
 
   useEffect(() => {
     const getImageSrc = async () => {
@@ -42,7 +69,7 @@ const usePublication = (id: string) => {
 
   const [{ data: result, fetching: loading }, executeQuery] = useQuery({
     query: GET_PUBLICATION_QUERY,
-    variables: { id },
+    variables: { id: publicationId },
   })
 
   const refetch = useCallback(() => executeQuery({ requestPolicy: "network-only" }), [executeQuery])
@@ -198,6 +225,7 @@ const usePublication = (id: string) => {
     loading,
     data,
     chainId,
+    publicationId,
     indexing,
     transactionCompleted,
     refetch,
@@ -211,4 +239,5 @@ const usePublication = (id: string) => {
   }
 }
 
+const getPublicationChainId = (publicationId: string) => Number(publicationId.split("-")[0])
 export default usePublication

--- a/packages/app/src/utils/validation.ts
+++ b/packages/app/src/utils/validation.ts
@@ -2,7 +2,7 @@ import { chainIdToChainName } from "../constants/chain"
 
 export const checkIsValidChain = (
   currentConnectedChainId: number,
-  publicationChainName?: string,
+  publicationChainId?: number,
 ): { network: string; isValid: boolean } => {
   const currentChainName = chainIdToChainName(currentConnectedChainId)
   if (currentChainName == null) {
@@ -10,9 +10,13 @@ export const checkIsValidChain = (
     return { network: "", isValid: false }
   }
 
-  if (publicationChainName == null) {
+  if (publicationChainId == null || publicationChainId === 0) {
     return { network: currentChainName, isValid: true }
   }
 
+  const publicationChainName = chainIdToChainName(publicationChainId)
+  if (publicationChainName == null) {
+    throw new Error("The publication is on an unsupported chain. This should not be possible.")
+  }
   return { network: publicationChainName, isValid: currentChainName === publicationChainName }
 }

--- a/packages/subgraph/network_configs/ropsten.json
+++ b/packages/subgraph/network_configs/ropsten.json
@@ -1,4 +1,0 @@
-{
-  "network": "ropsten",
-  "startBlock": 11919281
-}

--- a/packages/subgraph/src/article.mapping.ts
+++ b/packages/subgraph/src/article.mapping.ts
@@ -1,8 +1,9 @@
-import { JSONValue, TypedMap, log } from "@graphprotocol/graph-ts"
+import { JSONValue, TypedMap, log, dataSource } from "@graphprotocol/graph-ts"
 import { NewPost } from "../generated/Poster/Poster"
 import { Article, Publication } from "../generated/schema"
 import {
   getArticleId,
+  getIdFromContent,
   jsonToArrayString,
   jsonToString,
   SUB_ACTION__CREATE,
@@ -13,7 +14,7 @@ import { store } from "@graphprotocol/graph-ts"
 import { ARTICLE_ENTITY_TYPE } from "../tests/util"
 
 export function handleArticleAction(subAction: String, content: TypedMap<string, JSONValue>, event: NewPost): void {
-  let publicationId = jsonToString(content.get("publicationId"))
+  const publicationId = getIdFromContent(content, "publicationId")
 
   if (subAction == SUB_ACTION__CREATE) {
     let publication = Publication.load(publicationId)
@@ -48,7 +49,7 @@ export function handleArticleAction(subAction: String, content: TypedMap<string,
   }
 
   if (subAction == SUB_ACTION__UPDATE) {
-    const articleId = jsonToString(content.get("id"))
+    const articleId = getIdFromContent(content, "id")
     const article = Article.load(articleId)
 
     if (!article) {
@@ -111,7 +112,7 @@ export function handleArticleAction(subAction: String, content: TypedMap<string,
   }
 
   if (subAction == SUB_ACTION__DELETE) {
-    const articleId = jsonToString(content.get("id"))
+    const articleId = getIdFromContent(content, "id")
     const article = Article.load(articleId)
 
     if (!article) {

--- a/packages/subgraph/src/publication.mapping.ts
+++ b/packages/subgraph/src/publication.mapping.ts
@@ -4,6 +4,7 @@ import { Permission, Publication } from "../generated/schema"
 import {
   ACTION__ARTICLE,
   ACTION__PUBLICATION,
+  getIdFromContent,
   getPermissionId,
   getPublicationId,
   jsonToArrayString,
@@ -44,7 +45,7 @@ export function handlePublicationAction(subAction: String, content: TypedMap<str
     publication.save()
   }
   if (subAction == SUB_ACTION__UPDATE) {
-    const publicationId = jsonToString(content.get("id"))
+    const publicationId = getIdFromContent(content, "id")
     const publication = Publication.load(publicationId)
 
     if (!publication) {
@@ -80,7 +81,7 @@ export function handlePublicationAction(subAction: String, content: TypedMap<str
     }
   }
   if (subAction == SUB_ACTION__DELETE) {
-    const publicationId = jsonToString(content.get("id"))
+    const publicationId = getIdFromContent(content, "id")
     const publication = Publication.load(publicationId)
     if (publication == null) {
       log.error("Publication: Publication does not exist.", [publicationId])
@@ -103,7 +104,7 @@ export function handlePublicationAction(subAction: String, content: TypedMap<str
     return
   }
   if (subAction == SUB_ACTION__PERMISSIONS) {
-    const publicationId = jsonToString(content.get("id"))
+    const publicationId = getIdFromContent(content, "id")
     const publication = Publication.load(publicationId)
     const account = Address.fromString(jsonToString(content.get("account")))
     const newPermissions = content.get("permissions")

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -13,21 +13,45 @@ export const PUBLICATION_ENTITY_TYPE = "Publication"
 export const ARTICLE_ENTITY_TYPE = "Article"
 export const PERMISSION_ENTITY_TYPE = "Permission"
 
+// when adding new networks, it must be added here
+const networkToChainId = (theGraphNetworkName: string): i32 => {
+  if (theGraphNetworkName == "arbitrum-one") {
+    return 42161
+  } else if (theGraphNetworkName == "fantom") {
+    return 250
+  } else if (theGraphNetworkName == "xdai") {
+    return 100
+  } else if (theGraphNetworkName == "goerli") {
+    return 5
+  } else if (theGraphNetworkName == "mainnet") {
+    return 1
+  } else if (theGraphNetworkName == "optimism on gnosis chain") {
+    return 300
+  } else if (theGraphNetworkName == "optimism") {
+    return 10
+  } else if (theGraphNetworkName == "polygon") {
+    return 137
+  }
+  log.error("Utils: unknown chain (the `networkToChainId` function is missing the network name)", [theGraphNetworkName])
+  return 0
+}
+const chainId = networkToChainId(dataSource.network()).toString()
+
 export const getPublicationId = (event: NewPost): string =>
-  dataSource.network() + "-P-" + event.transaction.hash.toHex() + "-" + event.logIndex.toString()
+  chainId + "-P-" + event.transaction.hash.toHex() + "-" + event.logIndex.toString()
 
 export const getArticleId = (event: NewPost): string =>
-  dataSource.network() + "-A-" + event.transaction.hash.toHex() + "-" + event.logIndex.toString()
+  chainId + "-A-" + event.transaction.hash.toHex() + "-" + event.logIndex.toString()
 
 export const getPermissionId = (publicationId: string, user: Address): string =>
-  dataSource.network() + "-X-" + publicationId + "-" + user.toHex()
+  chainId + "-X-" + publicationId + "-" + user.toHex()
 
 // this will also update the id if it's in an old format
 
 // converts old IDs to new IDs (this function can be expanded later if we want to upgrade to another form of IDs later)
 const cleanId = (id: string): string => {
   if (id.startsWith("P-") || id.startsWith("A-") || id.startsWith("X-")) {
-    return dataSource.network() + "-" + id
+    return chainId + "-" + id
   } else {
     return id
   }


### PR DESCRIPTION
Parts of: #206. 
#206 is a large issue that will be split across multiple atomic PRs (each allowing for some new independent functionality).

This enables ENS resolution (for instance: http://localhost:3000/#/manboy.eth).
This required some changes:
- The subgraph IDs now include the chain id.
- The app routes changed.

Both changes are backward compatible; 
- Old links will redirect to the equivalent new link.
- Poster actions using old IDs will be handled (converted to new IDs when required).

This means that nothing should break for existing users.

See an example tabula-text record [here](https://app.ens.domains/name/manboy.eth/details).
<img width="954" alt="Screenshot 2023-02-03 at 14 39 54" src="https://user-images.githubusercontent.com/2156509/216617428-55f3bc69-8c0a-428c-8fba-682a7f2a243a.png">

The UI for setting the tabula ens text record is not part of the update. For now, this must be done in the ENS app (which will be added later).

Also, this does not include reverse lookup.

To test locally, use one of these updated subgraph endpoints (in `packages/app/.env`):
```
REACT_APP_SUBGRAPH_GOERLI=manboy-eth/tabula-goerli
REACT_APP_SUBGRAPH_GNOSIS_CHAIN=manboy-eth/tabula-gnosis-chain-2
```

Then you can go to http://localhost:3000/#/manboy.eth.