### PR TITLE
Resolved Header Placeholder Overlap and Style Issues

### DIFF
--- a/packages/app/src/components/commons/Editor/EditorBlock.tsx
+++ b/packages/app/src/components/commons/Editor/EditorBlock.tsx
@@ -25,6 +25,24 @@ const EditorBlockItem: React.FC<EditorBlockItemProps> = (props) => {
   const isFocused = props.blockProps.isFocused
   const type = props.block.getType()
 
+  const handleTop = (): number => {
+    switch (type) {
+      case "header-one":
+        return 12
+      case "header-two":
+        return 2
+      case "header-three":
+        return 10
+      case "header-four":
+        return 6
+      case "header-five":
+        return 4
+      case "header-six":
+        return 2
+      default:
+        return 0
+    }
+  }
   return (
     <Box
       sx={{
@@ -39,8 +57,10 @@ const EditorBlockItem: React.FC<EditorBlockItemProps> = (props) => {
       {isBlockFocused && isEmpty && isFocused && (
         <Typography
           variant="body1"
+          className="rich-editor-placeholder"
           sx={{
             position: "absolute",
+            top: handleTop,
             left: type.includes("ordered-list-item" || "unordered-list-item") ? 30 : 0,
             color: palette.grays[600],
           }}

--- a/packages/app/src/theme/index.ts
+++ b/packages/app/src/theme/index.ts
@@ -238,6 +238,11 @@ let theme = createTheme({
           overflow: auto;
           padding: 1rem;
         }
+        .rich-editor-placeholder{
+          font-family: ${fontFamilies.serif} !important;
+          font-size: 16px !important;
+          line-height: 1.75 !important;
+        }
         .public-DraftStyleDefault-pre {
           background-color: initial;
           border-radius: initial;


### PR DESCRIPTION
**Issue:**
closes #239

**Description:**

This PR addresses the issue: [Header placeholder elements cover the top of the image block and have incorrect styles](https://github.com/gnosis/tabula/issues/239). The placeholders for the headers were causing an overlap with the top of the image block and had incorrect styles applied.

**Changes:**

1. **EditorBlock.tsx** - Implemented a new function `handleTop()` to ensure correct spacing from the top, depending on the header type. It includes different return values for various header types ranging from "header-one" to "header-six". 

Code snippet:

```jsx
const handleTop = (): number => {
  switch (type) {
    case "header-one":
      return 12
    case "header-two":
      return 2
    case "header-three":
      return 10
    case "header-four":
      return 6
    case "header-five":
      return 4
    case "header-six":
      return 2
    default:
      return 0
  }
}
```

Also updated the styling for the Typography component. The `top` property now uses `handleTop` to correctly position the placeholder. 

Code snippet:

```jsx
<Typography
  variant="body1"
  className="rich-editor-placeholder"
  sx={{
    position: "absolute",
    top: handleTop,
    left: type.includes("ordered-list-item" || "unordered-list-item") ? 30 : 0,
    color: palette.grays[600],
  }}
/>
```

2. **theme/index.ts** - Added specific styles for the `.rich-editor-placeholder` class. This ensures the placeholders have the correct font family, font size, and line height.

Code snippet:

```tsx
.rich-editor-placeholder{
  font-family: ${fontFamilies.serif} !important;
  font-size: 16px !important;
  line-height: 1.75 !important;
}
```

These changes resolve the issue with header placeholder overlap and incorrect styles. Now, the placeholders display correctly according to their respective header types and do not overlap with image blocks.

**Test Plan:**

To verify these changes, create blocks with different header types and observe the placeholder position and style. There should no longer be any overlap with image blocks, and the placeholders should be styled correctly.

<img width="1724" alt="image" src="https://github.com/gnosis/tabula/assets/19823989/0bf43325-f902-450f-b6fc-62f7b819eb95">
<img width="1723" alt="image" src="https://github.com/gnosis/tabula/assets/19823989/c716b8c8-5220-4c9a-b792-6fb5a3de6660">



