### PR TITLE
Fix deterministic avatar functionality 

### DIFF
--- a/packages/app/src/components/commons/Avatar.tsx
+++ b/packages/app/src/components/commons/Avatar.tsx
@@ -11,9 +11,17 @@ interface AvatarProps {
   width: number
   storeImage?: boolean
   dynamicFavIcon?: boolean
+  forceGeneration?: boolean
 }
 
-const Avatar: React.FC<AvatarProps> = ({ publicationSlug, height, width, storeImage, dynamicFavIcon }) => {
+const Avatar: React.FC<AvatarProps> = ({
+  publicationSlug,
+  height,
+  width,
+  storeImage,
+  dynamicFavIcon,
+  forceGeneration,
+}) => {
   const { imageSrc, data: publication } = usePublication(publicationSlug)
   const { setPublicationAvatar } = usePublicationContext()
   const [avatar, setAvatar] = useState<string | undefined>(imageSrc)
@@ -27,7 +35,7 @@ const Avatar: React.FC<AvatarProps> = ({ publicationSlug, height, width, storeIm
   }
   return (
     <Fragment>
-      {imageSrc ? (
+      {imageSrc && !forceGeneration ? (
         <MaterialAvatar sx={{ width, height }} src={imageSrc}>
           {" "}
         </MaterialAvatar>

--- a/packages/app/src/components/commons/PublicationAvatar.tsx
+++ b/packages/app/src/components/commons/PublicationAvatar.tsx
@@ -4,6 +4,7 @@ import React, { ChangeEvent, useEffect, useRef, useState } from "react"
 import { palette, typography } from "../../theme"
 import AddIcon from "@mui/icons-material/Add"
 import ClearIcon from "@mui/icons-material/Clear"
+import EditIcon from "@mui/icons-material/Edit"
 import { useIpfs } from "../../hooks/useIpfs"
 import { usePublicationContext } from "../../services/publications/contexts"
 import { useDynamicFavIcon } from "../../hooks/useDynamicFavIco"
@@ -26,6 +27,7 @@ const PublicationAvatar: React.FC<PublicationAvatarProps> = ({ defaultImage, onF
   const inputFile = useRef<HTMLInputElement | null>(null)
   const openImagePicker = () => inputFile && inputFile.current?.click()
   const [uri, setUri] = useState<string | undefined>(undefined)
+  const [deterministicUri, setDeterministicUri] = useState<string>("")
   const [defaultImageSrc, setDefaultImageSrc] = useState<string>("")
   const { publicationAvatar, setRemovePublicationImage, removePublicationImage } = usePublicationContext()
 
@@ -65,6 +67,7 @@ const PublicationAvatar: React.FC<PublicationAvatarProps> = ({ defaultImage, onF
       getDefaultImageSrc()
     }
     if (!defaultImage && defaultImageSrc === "" && !removePublicationImage && publicationAvatar && !newPublication) {
+      setDeterministicUri(publicationAvatar.uri)
       setUri(publicationAvatar.uri)
       return setDefaultImageSrc(publicationAvatar.uri)
     }
@@ -119,7 +122,7 @@ const PublicationAvatar: React.FC<PublicationAvatarProps> = ({ defaultImage, onF
                 }}
                 onClick={deleteImage}
               >
-                <ClearIcon />
+                {deterministicUri === uri ? <EditIcon /> : <ClearIcon />}
               </SmallAvatar>
             )}
           </>

--- a/packages/app/src/components/views/publication/PublicationsView.tsx
+++ b/packages/app/src/components/views/publication/PublicationsView.tsx
@@ -19,6 +19,7 @@ import { CreatableSelect } from "../../commons/CreatableSelect"
 import { CreateSelectOption } from "../../../models/dropdown"
 import { usePosterContext } from "../../../services/poster/context"
 import { useDynamicFavIcon } from "../../../hooks/useDynamicFavIco"
+import { usePublicationContext } from "../../../services/publications/contexts"
 
 const PublicationsAvatarContainer = styled(Grid)(({ theme }) => ({
   display: "flex",
@@ -86,6 +87,7 @@ export const PublicationsView: React.FC<PublicationsViewProps> = ({ updateChainI
     setLastPublicationTitle,
     setExecutePollInterval,
   } = usePublications()
+  const { setPublicationAvatar } = usePublicationContext()
   const [tags, setTags] = useState<string[]>([])
   const [publicationsToShow, setPublicationsToShow] = useState<Publication[]>([])
   const [publicationImg, setPublicationImg] = useState<File>()
@@ -119,6 +121,10 @@ export const PublicationsView: React.FC<PublicationsViewProps> = ({ updateChainI
       handlePublicationsToShow(publications, account)
     }
   }, [publications, account])
+
+  useEffect(() => {
+    setPublicationAvatar(undefined)
+  }, [setPublicationAvatar])
 
   useEffect(() => {
     if (redirect && lastPublicationId) {


### PR DESCRIPTION
**Description:**

Closes #223 

**Issue**
The UI of the avatar was misleading as it implied a user could have a blank avatar, which was not the case. Instead, a user with a deterministic avatar set as their publication avatar should see an "edit" icon instead of the "x", and clicking on the "edit" should only update the avatar if a valid file is selected from the file prompt. 

**Solution**
This PR implements several changes to address the above issue:

Changes in `PublicationAvatar.tsx`:

1. Imported `EditIcon` from `@mui/icons-material/Edit`.
2. Initialized a new state variable `deterministicUri` to keep track of the deterministic avatar URL.
3. Added a conditional check to set the `deterministicUri`, `uri`, and `defaultImageSrc` if no default image is set, no remove publication image is requested, and a publication avatar exists.
4. Added a conditional rendering of `EditIcon` or `ClearIcon` based on whether `deterministicUri` equals `uri`.

With these changes, a user's deterministic avatar will remain as the publication avatar until a valid file is selected, improving user experience and expectations.

**Testing**
Tested the changes and confirmed that the "edit" icon is now displayed instead of the "x" for users with deterministic avatars, and that the avatar only updates upon selection of a valid file.

https://github.com/gnosis/tabula/assets/19823989/569af22d-c5f1-4ef6-8890-bcf3848ad50c



