### PR TITLE
Enable Spell Check in Draft-js Editor Component

### DIFF
--- a/packages/app/src/components/commons/Editor/Editor.tsx
+++ b/packages/app/src/components/commons/Editor/Editor.tsx
@@ -332,6 +332,7 @@ const Editor: React.FC = () => {
         keyBindingFn={keyBindingFn}
         handleReturn={handleReturn}
         customStyleMap={styleMap}
+        spellCheck={true} 
       />
       <EditorInlineText
         showCommand={showInlinePopup}


### PR DESCRIPTION
Description:

closes #234 

This PR introduces a small, but meaningful, change to the `Editor` component within our application. By setting the `spellCheck` prop to `true`, we're enabling the browser's built-in spell checker to highlight and suggest corrections for misspelled words in our text editor.

**Changes:**
- Set `spellCheck={true}` in `Editor` component

This will greatly enhance the user experience, especially for users who rely on the spell checker for accuracy in their written content. 

**Important Note:** This change requires that the spell check feature of the user's browser is enabled. The spell check functionality might not work if the browser's spell check feature is turned off or not correctly set up.

Instructions on how to enable the browser's spell check feature usually vary between browsers, but generally it is found under the Language settings. Users should ensure that they have at least one language selected for spell checking.

<img width="1728" alt="image" src="https://github.com/gnosis/tabula/assets/19823989/0ef13066-8ef6-4010-b1e1-1616729cd9f2">

<img width="1722" alt="image" src="https://github.com/gnosis/tabula/assets/19823989/a0624b90-8c6d-4501-9bf5-f4229761d63b">

