### PR TITLE
Fix auto-scrolling issue when adding new lines

### DIFF
--- a/packages/app/src/components/commons/Editor/Editor.tsx
+++ b/packages/app/src/components/commons/Editor/Editor.tsx
@@ -47,6 +47,7 @@ const Editor: React.FC = () => {
     setContentImageFiles,
     setLinkComponentUrl,
   } = useArticleContext()
+  const editorContainer = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
   const linkDecorator = useLinkDecorator()
   const decorators = new CompositeDecorator(linkDecorator)
@@ -217,6 +218,23 @@ const Editor: React.FC = () => {
     }
   }, [editorState, setShowInlinePopup])
 
+  useEffect(() => {
+    scrollToBottom()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorState])
+
+  // go to the end of the text editor
+  const scrollToBottom = () => {
+    const currentSelection = editorState.getSelection()
+    const anchorKey = currentSelection.getAnchorKey()
+    const currentContent = editorState.getCurrentContent()
+    const currentBlock = currentContent.getBlockForKey(anchorKey)
+
+    //check if the current blocks is the last
+    if (currentBlock === currentContent.getLastBlock()) {
+      editorContainer.current?.scrollIntoView({ behavior: "smooth", block: "end" })
+    }
+  }
   const handleState = (editorState: EditorState) => {
     const finalEditorState = handleSlashCommand(editorState)
     setEditorState(finalEditorState)
@@ -322,7 +340,7 @@ const Editor: React.FC = () => {
   }
 
   return (
-    <Box>
+    <Box ref={editorContainer}>
       <DraftEditor
         ref={editor}
         editorState={editorState}


### PR DESCRIPTION
**Description:**

closes #230 

This PR addresses an odd UX behavior in the text editor. Before the fix, when a user was adding new lines at the bottom of the page, the editor didn't automatically scroll to the new line. Instead, it waited until the user began typing. This issue also affected pasted text, where the editor did not respond at all. 

**Changes include:**
- A new `useEffect` hook which updates the editor state to focus on the new line once it's created.
- The addition of `scrollIntoViewIfNeeded` to ensure that the new line is brought into view when added, even if it's created by pasting text from the clipboard.

With these changes, the editor should now auto-scroll to a new line when it's created, improving the user experience.

**Testing**

https://github.com/gnosis/tabula/assets/19823989/b17b4e8a-3f75-4ec7-8851-29007e4e0aca



