### PR TITLE
Bug: solve code and quote break/return

### DIFF
--- a/packages/app/src/components/commons/Editor/Editor.tsx
+++ b/packages/app/src/components/commons/Editor/Editor.tsx
@@ -32,6 +32,7 @@ import EditorImagePicker from "./EditorComponents/EditorImagePicker"
 import EditorLink from "./EditorComponents/EditorLink"
 import EditorShowImage from "./EditorComponents/EditoShowImage"
 import { palette, typography } from "../../../theme"
+import useHandlePastedText from "./hooks/useHandlePasteText"
 
 const { hasCommandModifier } = KeyBindingUtil
 type Config = IConvertToHTMLConfig<DraftInlineStyleType, string, RawDraftEntity>
@@ -351,6 +352,7 @@ const Editor: React.FC = () => {
         handleReturn={handleReturn}
         customStyleMap={styleMap}
         spellCheck={true} 
+        handlePastedText={useHandlePastedText(editorState, setEditorState)}
       />
       <EditorInlineText
         showCommand={showInlinePopup}

--- a/packages/app/src/components/commons/Editor/EditorBlock.tsx
+++ b/packages/app/src/components/commons/Editor/EditorBlock.tsx
@@ -48,8 +48,8 @@ const EditorBlockItem: React.FC<EditorBlockItemProps> = (props) => {
       sx={{
         position: "relative",
         cursor: "text",
-        mt: 1,
-        mb: isBlockFocused && isEmpty && isFocused ? 1 : 0,
+        mt: type.includes("code-block") ? 0 : 1,
+
         "&:hover .rich-text": {
           opacity: 1,
         },

--- a/packages/app/src/components/commons/Editor/EditorBlock.tsx
+++ b/packages/app/src/components/commons/Editor/EditorBlock.tsx
@@ -49,6 +49,7 @@ const EditorBlockItem: React.FC<EditorBlockItemProps> = (props) => {
         position: "relative",
         cursor: "text",
         mt: 1,
+        mb: isBlockFocused && isEmpty && isFocused ? 1 : 0,
         "&:hover .rich-text": {
           opacity: 1,
         },
@@ -62,7 +63,7 @@ const EditorBlockItem: React.FC<EditorBlockItemProps> = (props) => {
             position: "absolute",
             top: handleTop,
             left: type.includes("ordered-list-item" || "unordered-list-item") ? 30 : 0,
-            color: palette.grays[600],
+            color: type.includes("code-block") ? palette.whites[600] : palette.grays[600],
           }}
         >
           Type '/' for commands...

--- a/packages/app/src/components/commons/Editor/hooks/useHandlePasteText.ts
+++ b/packages/app/src/components/commons/Editor/hooks/useHandlePasteText.ts
@@ -1,0 +1,21 @@
+import { EditorState, DraftHandleValue, Modifier } from "draft-js"
+
+const useHandlePastedText = (
+  editorState: EditorState,
+  setEditorState: React.Dispatch<React.SetStateAction<EditorState>>,
+) => {
+  return (text: string, html: string | undefined, editorState: EditorState): DraftHandleValue => {
+    // We obtain the current content and selection;
+    const contentState = editorState.getCurrentContent()
+    const selectionState = editorState.getSelection()
+    
+    // Replace the text selected with the copied text and we use it as one block
+    const newContentState = Modifier.replaceText(contentState, selectionState, text)
+    const newEditorState = EditorState.push(editorState, newContentState, "insert-fragment")
+
+    setEditorState(newEditorState)
+    return "handled"
+  }
+}
+
+export default useHandlePastedText

--- a/packages/app/src/components/commons/Editor/hooks/useHandleReturn.ts
+++ b/packages/app/src/components/commons/Editor/hooks/useHandleReturn.ts
@@ -1,4 +1,4 @@
-import { EditorState, DraftHandleValue, RichUtils } from "draft-js"
+import { EditorState, DraftHandleValue, Modifier, RichUtils } from "draft-js"
 
 const useHandleReturn = (
   editorState: EditorState,
@@ -6,12 +6,21 @@ const useHandleReturn = (
   hasCommandModifier: (e: React.KeyboardEvent) => boolean,
 ) => {
   return (e: React.KeyboardEvent): DraftHandleValue => {
-    if (e.altKey || !hasCommandModifier(e)) {
-      return "not-handled"
-    }
+    if (e.shiftKey) {
+      // If we press shift + return, add new line
+      setEditorState(RichUtils.insertSoftNewline(editorState))
+      return "handled"
+    } else {
+      // If we press return without shift, we create a new block
+      const contentState = editorState.getCurrentContent()
+      const selectionState = editorState.getSelection()
 
-    setEditorState(RichUtils.insertSoftNewline(editorState))
-    return "handled"
+      const newContentState = Modifier.splitBlock(contentState, selectionState)
+      const newEditorState = EditorState.push(editorState, newContentState, "split-block")
+
+      setEditorState(newEditorState)
+      return "handled"
+    }
   }
 }
 

--- a/packages/app/src/components/commons/Editor/hooks/useHandleReturn.ts
+++ b/packages/app/src/components/commons/Editor/hooks/useHandleReturn.ts
@@ -15,7 +15,8 @@ const useHandleReturn = (
       const contentState = editorState.getCurrentContent()
       const selectionState = editorState.getSelection()
 
-      const newContentState = Modifier.splitBlock(contentState, selectionState)
+      let newContentState = Modifier.splitBlock(contentState, selectionState)
+      newContentState = Modifier.setBlockType(newContentState, newContentState.getSelectionAfter(), "unstyled")
       const newEditorState = EditorState.push(editorState, newContentState, "split-block")
 
       setEditorState(newEditorState)

--- a/packages/app/src/theme/index.ts
+++ b/packages/app/src/theme/index.ts
@@ -236,7 +236,8 @@ let theme = createTheme({
           font-family: ${typography.fontFamilies.monospace};
           margin-bottom: 1rem;
           overflow: auto;
-          padding: 1rem;
+          padding: 0.5rem;
+          font-size: 13px;
         }
         .rich-editor-placeholder{
           font-family: ${fontFamilies.serif} !important;


### PR DESCRIPTION
Closes #231 #233 

## **Description:**

This PR introduces updates to the Draft.js editor for better handling of `return` key presses and pasted text blocks.

### Changes:

1. **Handle Return Key:** We have updated the way the `return` key is handled. Now, when the user presses `shift + return`, a soft line break is inserted, allowing them to continue in the same block. If only the `return` key is pressed without `shift`, a new paragraph block is created. This was achieved by creating a custom `useHandleReturn` hook.

2. **Handle Pasted Text:** We've added a new feature that treats pasted multi-line text as a single block, rather than creating a new block for each new line. This ensures that large blocks of code or quotes pasted from an external source are kept intact as a single block. This was implemented with the `useHandlePastedText` hook.

### How to Test:

- For Return Key:
  - Press `shift + return` in the editor, it should insert a soft line break, keeping you in the same block.
  - Press `return` without `shift`, it should create a new paragraph block.

- For Pasted Text:
  - Paste a multi-line text block into the editor, it should be treated as a single block.
  
### Test 
https://github.com/gnosis/tabula/assets/19823989/1407b8d3-7b50-45ee-b3db-4b4c42554287

 

These enhancements improve the user experience by allowing more control over the text formatting and structure.

