### PR TITLE
Implement Markdown parsing in useHandlePastedText

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,6 +37,7 @@
     "is-ipfs": "^6.0.2",
     "lodash": "^4.17.21",
     "markdown-to-jsx": "^7.1.7",
+    "marked": "^5.1.2",
     "moment": "^2.29.2",
     "notistack": "^2.0.8",
     "react": "^17.0.2",
@@ -89,6 +90,7 @@
     "@types/draft-convert": "^2.1.4",
     "@types/draft-js": "^0.11.10",
     "@types/lodash": "^4.14.180",
+    "@types/marked": "^5.0.1",
     "@types/turndown": "^5.0.1",
     "prettier": "^2.5.1"
   },

--- a/packages/app/src/components/commons/Editor/EditorRichText.tsx
+++ b/packages/app/src/components/commons/Editor/EditorRichText.tsx
@@ -306,6 +306,7 @@ const EditorRichText: React.FC<RichTextProps> = ({ onRichTextSelected, showComma
     return () => {
       window.removeEventListener("keydown", handleKeyDown)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show])
 
   useEffect(() => {
@@ -363,7 +364,7 @@ const EditorRichText: React.FC<RichTextProps> = ({ onRichTextSelected, showComma
     if (show && headerOptionRefs[0].current) {
       headerOptionRefs[0].current.focus()
     }
-  }, [show])
+  }, [headerOptionRefs, show])
 
   return (
     <>

--- a/packages/app/src/components/commons/Editor/hooks/useHandlePasteText.ts
+++ b/packages/app/src/components/commons/Editor/hooks/useHandlePasteText.ts
@@ -1,17 +1,44 @@
-import { EditorState, DraftHandleValue, Modifier } from "draft-js"
+import { EditorState, DraftHandleValue, Modifier, convertFromHTML, ContentState } from "draft-js"
+import { marked } from "marked"
 
 const useHandlePastedText = (
   editorState: EditorState,
   setEditorState: React.Dispatch<React.SetStateAction<EditorState>>,
 ) => {
+  const isMarkdown = (text: string) => {
+    // These are just some of the characters commonly used in markdown.
+    const markdownCharacters = ["#", "*", "_", "~", "[", "]", "(", ")", "|", "`", ">", "-"]
+
+    //markdown text
+    for (let character of markdownCharacters) {
+      if (text.includes(character)) {
+        return true
+      }
+    }
+
+    //If none of the markdown characters are found, we assume it is not markdown.
+    return false
+  }
+
   return (text: string, html: string | undefined, editorState: EditorState): DraftHandleValue => {
     // We obtain the current content and selection;
     const contentState = editorState.getCurrentContent()
     const selectionState = editorState.getSelection()
-    
-    // Replace the text selected with the copied text and we use it as one block
-    const newContentState = Modifier.replaceText(contentState, selectionState, text)
-    const newEditorState = EditorState.push(editorState, newContentState, "insert-fragment")
+
+    let newContentState: ContentState
+
+    if (isMarkdown(text)) {
+      // you need to implement isMarkdown function
+      // If the pasted text is Markdown, treat it as such
+      const markdownHTML = marked(text) // Convert Markdown to HTML
+      const contentBlockArray = convertFromHTML(markdownHTML) // Convert HTML to Draft.js blocks
+      newContentState = ContentState.createFromBlockArray(contentBlockArray.contentBlocks, contentBlockArray.entityMap)
+    } else {
+      // If the pasted text is not Markdown, handle it as plain text
+      newContentState = Modifier.replaceText(contentState, selectionState, text)
+    }
+
+    const newEditorState = EditorState.push(editorState, newContentState, "insert-characters")
 
     setEditorState(newEditorState)
     return "handled"

--- a/packages/app/yarn.lock
+++ b/packages/app/yarn.lock
@@ -2826,6 +2826,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/marked@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-5.0.1.tgz#15acd796d722b91bf00738c8c8539aaf5034f0c6"
+  integrity sha512-Y3pAUzHKh605fN6fvASsz5FDSWbZcs/65Q6xYRmnIP9ZIYz27T4IOmXfH9gWJV1dpi7f1e7z7nBGUTx/a0ptpA==
+
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
@@ -10961,6 +10966,11 @@ markdown-to-jsx@^7.1.7:
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.9.tgz#1ffae0cda07c189163d273bd57a5b8f8f8745586"
   integrity sha512-x4STVIKIJR0mGgZIZ5RyAeQD7FEZd5tS8m/htbcVGlex32J+hlSLj+ExrHCxP6nRKF1EKbcO7i6WhC1GtOpBlA==
+
+marked@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-5.1.2.tgz#62b5ccfc75adf72ca3b64b2879b551d89e77677f"
+  integrity sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==
 
 match-sorter@^6.0.2:
   version "6.3.1"


### PR DESCRIPTION
## Description

This PR addresses the request in issue #236. It involves modifying the `useHandlePastedText` method to handle Markdown formatted text.

## Changes Implemented:

1. Added `marked` library to parse Markdown into HTML.
2. The method `isMarkdown` has been added to identify if the incoming pasted text is in Markdown format. It checks for common Markdown syntax characters such as "#", "*", "_", "~", "[", "]", "(", ")", "|", "`", ">", "-".
3. If the text is identified as Markdown, it is first converted to HTML using `marked`. The HTML is then parsed into Draft.js blocks using `convertFromHTML`. The resulting blocks replace the current selection in the editor.
4. If the text is not identified as Markdown, it's treated as plain text and the function behaves as it did originally - replacing the current selection with the plain text.

Here's a sample Markdown snippet for testing:

```markdown
# Heading

This is a paragraph with **bold text**, _italic text_, text with a [link](https://www.example.com), and `inline code`.

1. This is the first item in an ordered list
2. This is the second item on the ordered list
   - This is the first item in a nested unordered list
   - This is the second item in the nested unordered list

> This is a quote

***
This is a divider line

```python
# This is a code block
print('Hello, world!')```
```

This Markdown text covers all the scenarios we are aiming to handle with this PR.

## Test Record

https://github.com/gnosis/tabula/assets/19823989/a7b0750e-cf1d-4a17-935b-06b9c6afe630

